### PR TITLE
name change from subcontractor to team member :)

### DIFF
--- a/app/[locale]/contacts/page.tsx
+++ b/app/[locale]/contacts/page.tsx
@@ -151,7 +151,7 @@ export default function ClientsPage() {
                 )}
               >
                 <Wrench className="h-4 w-4" />
-                Subcontractors
+                Team members
               </button>
             </div>
 
@@ -168,7 +168,7 @@ export default function ClientsPage() {
                 <div className="flex-1 min-w-0">
                   <input
                     type="text"
-                    placeholder="Search subcontractors..."
+                    placeholder="Search team members..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     className="w-full sm:max-w-xs h-10 rounded-lg border border-slate-200 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
@@ -212,7 +212,7 @@ export default function ClientsPage() {
                     onClick={() => setAddSubOpen(true)}
                   >
                     <Plus className="h-5 w-5 shrink-0 mr-2" />
-                    Add Subcontractor
+                    Add Team Member
                   </Button>
                 )}
               </div>

--- a/components/add-subcontractor-form.tsx
+++ b/components/add-subcontractor-form.tsx
@@ -54,7 +54,7 @@ export function AddSubcontractorForm({ open, onOpenChange, onSuccess }: AddSubco
                 address: form.address.trim() || undefined,
                 notes: form.notes.trim() || undefined,
             })
-            toast({ title: "Subcontractor added successfully" })
+            toast({ title: "Team member added successfully" })
             setForm({ name: "", email: "", phone_number: "", company_name: "", address: "", notes: "" })
             onOpenChange(false)
             onSuccess?.()
@@ -69,7 +69,7 @@ export function AddSubcontractorForm({ open, onOpenChange, onSuccess }: AddSubco
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="sm:max-w-md">
                 <DialogHeader>
-                    <DialogTitle>Add Subcontractor</DialogTitle>
+                    <DialogTitle>Add Team Member</DialogTitle>
                 </DialogHeader>
                 <form onSubmit={handleSubmit} className="space-y-4">
                     <div className="space-y-2">
@@ -136,7 +136,7 @@ export function AddSubcontractorForm({ open, onOpenChange, onSuccess }: AddSubco
                             Cancel
                         </Button>
                         <Button type="submit" disabled={saving}>
-                            {saving ? "Saving..." : "Add Subcontractor"}
+                            {saving ? "Saving..." : "Add Team Member"}
                         </Button>
                     </DialogFooter>
                 </form>

--- a/components/projects/edit-trade-dialog.tsx
+++ b/components/projects/edit-trade-dialog.tsx
@@ -206,13 +206,13 @@ export function EditTradeDialog({
                                 <UploadCloud className="w-4 h-4 mr-2" /> GC Prep Attachments <span className="ml-2 bg-green-100 text-green-700 px-2 py-0.5 rounded-full text-xs">{trade.reference_media?.length || 0}</span>
                             </TabsTrigger>
                             <TabsTrigger value="sub" className="rounded-none font-semibold text-slate-500 data-[state=active]:bg-slate-50 data-[state=active]:text-slate-900 h-full">
-                                Sub Proof-of-Work <span className="ml-2 bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full text-xs">{trade.proof_of_work_media?.length || 0}</span>
+                                Team Member Proof-of-Work <span className="ml-2 bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full text-xs">{trade.proof_of_work_media?.length || 0}</span>
                             </TabsTrigger>
                         </TabsList>
                         <div className="bg-white">
                             <TabsContent value="gc" className="m-0 p-6 space-y-4 border-b border-slate-200">
                                 <p className="text-sm text-slate-500">
-                                    Upload reference photos or attachments for the subcontractor. You can add, view, or remove these files.
+                                    Upload reference photos or attachments for the team member. You can add, view, or remove these files.
                                 </p>
                                 <div className="flex flex-wrap gap-4">
                                     {trade.reference_media?.map(m => (
@@ -249,7 +249,7 @@ export function EditTradeDialog({
                             </TabsContent>
                             <TabsContent value="sub" className="m-0 p-6 space-y-4 border-b border-slate-200">
                                 <p className="text-sm text-slate-500">
-                                    Proof-of-work media uploaded by the Subcontractor. You cannot delete these.
+                                    Proof-of-work media uploaded by the team member. You cannot delete these.
                                 </p>
                                 <div className="flex flex-wrap gap-4">
                                     {trade.proof_of_work_media?.map(m => (

--- a/components/projects/new-trade-dialog.tsx
+++ b/components/projects/new-trade-dialog.tsx
@@ -126,7 +126,7 @@ export function NewTradeDialog({
     const handleSubmit = async () => {
         const missing: string[] = []
         if (!tradeType.trim()) missing.push("Trade Type")
-        if (!subcontractorName.trim()) missing.push("Subcontractor Name")
+        if (!subcontractorName.trim()) missing.push("Team Member Name")
         if (!scopeOfWork.trim()) missing.push("Scope of Work")
         if (missing.length > 0) {
             toast({
@@ -207,7 +207,7 @@ export function NewTradeDialog({
                     </div>
 
                     <div className="space-y-1.5 flex flex-col">
-                        <Label className="text-sm font-medium text-slate-700 uppercase p-1">Subcontractor Name</Label>
+                        <Label className="text-sm font-medium text-slate-700 uppercase p-1">Team Member Name</Label>
                         <Popover open={openCombobox} onOpenChange={setOpenCombobox}>
                             <PopoverTrigger asChild>
                                 <Button
@@ -218,7 +218,7 @@ export function NewTradeDialog({
                                     className="w-full justify-between font-normal text-left text-slate-700 bg-white hover:bg-slate-50 border-slate-200 h-10 px-3"
                                 >
                                     <span className="truncate">
-                                        {subcontractorName ? subcontractorName : <span className="text-slate-400">Select or enter a subcontractor...</span>}
+                                        {subcontractorName ? subcontractorName : <span className="text-slate-400">Select or enter a team member...</span>}
                                     </span>
                                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                                 </Button>
@@ -234,7 +234,7 @@ export function NewTradeDialog({
                                     <CommandList>
                                         <CommandEmpty>
                                             <div className="flex flex-col items-start px-2 py-1">
-                                                <span className="text-sm text-slate-500 mb-1">No subcontractor found.</span>
+                                                <span className="text-sm text-slate-500 mb-1">No team member found.</span>
                                                 <Button
                                                     variant="ghost"
                                                     className="h-auto p-1.5 px-3 text-sm flex justify-start text-blue-600 hover:text-blue-700 hover:bg-blue-50 w-full"
@@ -303,7 +303,7 @@ export function NewTradeDialog({
                     </div>
 
                     <div className="space-y-1.5">
-                        <Label className="text-sm font-medium text-slate-700 uppercase p-1">Subcontractor Email</Label>
+                        <Label className="text-sm font-medium text-slate-700 uppercase p-1">Team Member Email</Label>
                         <Input placeholder="e.g. henry@example.com" type="email" value={subcontractorEmail} onChange={e => setSubcontractorEmail(e.target.value)} />
                     </div>
 
@@ -344,7 +344,7 @@ export function NewTradeDialog({
                             <UploadCloud className="h-5 w-5 text-blue-500" /> Upload Prep / Reference Attachments <span className="text-slate-400 font-normal text-sm">(optional)</span>
                         </div>
                         <p className="text-sm text-slate-500 mb-4">
-                            Upload reference photos or attachments for the subcontractor before assigning this scope.
+                            Upload reference photos or attachments for the team member before assigning this scope.
                         </p>
 
                         <label className="w-full p-6 border-2 border-dashed border-slate-200 rounded-xl bg-slate-50 flex flex-col items-center justify-center hover:bg-slate-100 transition-colors cursor-pointer">

--- a/components/projects/trades-scopes.tsx
+++ b/components/projects/trades-scopes.tsx
@@ -162,7 +162,7 @@ export function TradesScopes({ project, onTradesUpdated }: TradesScopesProps) {
                   <TableHeader>
                     <TableRow className="border-slate-200 bg-slate-50/80 hover:bg-slate-50/80">
                       <TableHead className="px-4 text-slate-600 font-medium">Trade</TableHead>
-                      <TableHead className="px-4 text-slate-600 font-medium">Subcontractor</TableHead>
+                      <TableHead className="px-4 text-slate-600 font-medium">Team Member</TableHead>
                       <TableHead className="px-4 text-slate-600 font-medium">Scope Details</TableHead>
                       <TableHead className="px-4 text-slate-600 font-medium whitespace-nowrap">Agreed Price</TableHead>
                       <TableHead className="px-4 text-slate-600 font-medium">Status</TableHead>

--- a/components/subcontractors-list.tsx
+++ b/components/subcontractors-list.tsx
@@ -70,7 +70,7 @@ export function SubcontractorsList({
         if (!archiveTarget) return
         try {
             await api.deleteSubcontractor(archiveTarget)
-            toast({ title: "Subcontractor archived" })
+            toast({ title: "Team member archived" })
             onSubcontractorArchived?.()
         } catch (err: any) {
             toast({ title: "Failed to archive", description: err.message, variant: "destructive" })
@@ -93,8 +93,8 @@ export function SubcontractorsList({
         return (
             <div className="flex flex-col items-center justify-center py-16 text-center">
                 <Building2 className="h-12 w-12 text-slate-300 mb-4" />
-                <h3 className="text-lg font-semibold text-slate-700 mb-1">No subcontractors yet</h3>
-                <p className="text-sm text-slate-500">Add your first subcontractor to get started.</p>
+                <h3 className="text-lg font-semibold text-slate-700 mb-1">No team members yet</h3>
+                <p className="text-sm text-slate-500">Add your first team member to get started.</p>
             </div>
         )
     }
@@ -147,8 +147,8 @@ export function SubcontractorsList({
                 <AlertDialog open={!!archiveTarget} onOpenChange={(open) => !open && setArchiveTarget(null)}>
                     <AlertDialogContent>
                         <AlertDialogHeader>
-                            <AlertDialogTitle>Archive subcontractor?</AlertDialogTitle>
-                            <AlertDialogDescription>This will archive the subcontractor. You can reactivate them later.</AlertDialogDescription>
+                            <AlertDialogTitle>Archive team member?</AlertDialogTitle>
+                            <AlertDialogDescription>This will archive the team member. You can reactivate them later.</AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
                             <AlertDialogCancel>Cancel</AlertDialogCancel>
@@ -228,8 +228,8 @@ export function SubcontractorsList({
             <AlertDialog open={!!archiveTarget} onOpenChange={(open) => !open && setArchiveTarget(null)}>
                 <AlertDialogContent>
                     <AlertDialogHeader>
-                        <AlertDialogTitle>Archive subcontractor?</AlertDialogTitle>
-                        <AlertDialogDescription>This will archive the subcontractor. You can reactivate them later.</AlertDialogDescription>
+                        <AlertDialogTitle>Archive team member?</AlertDialogTitle>
+                        <AlertDialogDescription>This will archive the team member. You can reactivate them later.</AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
                         <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/messages/en.json
+++ b/messages/en.json
@@ -215,7 +215,7 @@
   },
   "projects": {
     "title": "Projects",
-    "subtitle": "Track execution timelines, punch lists, documents, and subcontractor scopes in one place.",
+    "subtitle": "Track execution timelines, punch lists, documents, and team member scopes in one place.",
     "createProject": "New Project",
     "untitledProject": "Untitled project",
     "filterLabel": "Filtered by status",


### PR DESCRIPTION
This pull request standardizes terminology across the app by replacing all instances of "subcontractor" with "team member" in the user interface, including labels, placeholders, messages, and dialog titles. This improves clarity and consistency for users interacting with project and contact management features.

**UI Text and Label Updates:**

* All references to "subcontractor" have been changed to "team member" across buttons, placeholders, dialog titles, table headers, and notifications in `app/[locale]/contacts/page.tsx`, `components/add-subcontractor-form.tsx`, `components/subcontractors-list.tsx`, and `components/projects/trades-scopes.tsx`. ([app/[locale]/contacts/page.tsxL154-R154](diffhunk://#diff-0719515e7503bdacfde0d3fcee78c4efa15b289cf699be5ddbc66b87a535f8c2L154-R154), [app/[locale]/contacts/page.tsxL171-R171](diffhunk://#diff-0719515e7503bdacfde0d3fcee78c4efa15b289cf699be5ddbc66b87a535f8c2L171-R171), [app/[locale]/contacts/page.tsxL215-R215](diffhunk://#diff-0719515e7503bdacfde0d3fcee78c4efa15b289cf699be5ddbc66b87a535f8c2L215-R215), [[1]](diffhunk://#diff-918f45db138573b0648585407e0a750259cbf293dab337a6ef543fc2dbb7acd0L57-R57) [[2]](diffhunk://#diff-918f45db138573b0648585407e0a750259cbf293dab337a6ef543fc2dbb7acd0L72-R72) [[3]](diffhunk://#diff-918f45db138573b0648585407e0a750259cbf293dab337a6ef543fc2dbb7acd0L139-R139) [[4]](diffhunk://#diff-43300a0810208842f62c9cf7325ccc58174bbe25a8232c5b80516e557da65cd5L73-R73) [[5]](diffhunk://#diff-43300a0810208842f62c9cf7325ccc58174bbe25a8232c5b80516e557da65cd5L96-R97) [[6]](diffhunk://#diff-43300a0810208842f62c9cf7325ccc58174bbe25a8232c5b80516e557da65cd5L150-R151) [[7]](diffhunk://#diff-43300a0810208842f62c9cf7325ccc58174bbe25a8232c5b80516e557da65cd5L231-R232) [[8]](diffhunk://#diff-666d3b48f27b2a8827e0259971cd246b504dd3d312f6b58daf4ae7fc3bc466c3L165-R165)

**Project and Trade Dialogs:**

* All form labels, placeholders, and prompts in project-related dialogs now refer to "team member" instead of "subcontractor" in `components/projects/new-trade-dialog.tsx` and `components/projects/edit-trade-dialog.tsx`. [[1]](diffhunk://#diff-a9df9bd75bb27077b0ef3c20fb5434e6d17985af19a2cec3942ed7ed7732bdbeL129-R129) [[2]](diffhunk://#diff-a9df9bd75bb27077b0ef3c20fb5434e6d17985af19a2cec3942ed7ed7732bdbeL210-R210) [[3]](diffhunk://#diff-a9df9bd75bb27077b0ef3c20fb5434e6d17985af19a2cec3942ed7ed7732bdbeL221-R221) [[4]](diffhunk://#diff-a9df9bd75bb27077b0ef3c20fb5434e6d17985af19a2cec3942ed7ed7732bdbeL237-R237) [[5]](diffhunk://#diff-a9df9bd75bb27077b0ef3c20fb5434e6d17985af19a2cec3942ed7ed7732bdbeL306-R306) [[6]](diffhunk://#diff-a9df9bd75bb27077b0ef3c20fb5434e6d17985af19a2cec3942ed7ed7732bdbeL347-R347) [[7]](diffhunk://#diff-5a1948508fb7073690621fe86456e48ef27a223973469592d25a9c712894ce22L209-R215) [[8]](diffhunk://#diff-5a1948508fb7073690621fe86456e48ef27a223973469592d25a9c712894ce22L252-R252)

**Localization:**

* The English translation file (`messages/en.json`) has been updated to use "team member scopes" instead of "subcontractor scopes" in the projects subtitle.