### PR TITLE
Add Scope & Billing tab + "Add from quote" picker; re-skin financials on design tokens

### DIFF
--- a/components/projects/financials/documents-change-orders-tab.tsx
+++ b/components/projects/financials/documents-change-orders-tab.tsx
@@ -13,16 +13,16 @@ export function DocumentsChangeOrdersTab({ project }: DocumentsChangeOrdersTabPr
     <div className="p-6 grid grid-cols-1 xl:grid-cols-2 gap-8">
       {/* 1. Documents */}
       <div className="space-y-4">
-        <h2 className="text-lg font-bold text-slate-800 tracking-tight pb-2 border-b">Project Documents & Receipts</h2>
-        <div className="bg-slate-50 rounded-lg p-1 border">
+        <h2 className="text-lg font-bold text-foreground tracking-tight pb-2 border-b">Project Documents & Receipts</h2>
+        <div className="bg-muted rounded-lg p-1 border">
            <ProjectDocuments project={project} />
         </div>
       </div>
 
       {/* 2. Change Orders Detailed View */}
       <div className="space-y-4">
-        <h2 className="text-lg font-bold text-slate-800 tracking-tight pb-2 border-b">Change Orders (Contracts & Signatures)</h2>
-        <div className="bg-slate-50 rounded-lg p-1 border">
+        <h2 className="text-lg font-bold text-foreground tracking-tight pb-2 border-b">Change Orders (Contracts & Signatures)</h2>
+        <div className="bg-muted rounded-lg p-1 border">
            <ProjectChangeOrders 
               jobId={project.job_id!}
            />

--- a/components/projects/financials/financial-sidebar.tsx
+++ b/components/projects/financials/financial-sidebar.tsx
@@ -7,7 +7,7 @@ import { Project, ProjectPayment, ProjectFinancialSummary, FinancialPaymentMetho
 import { api } from '@/lib/api'
 import { useToast } from '@/components/ui/use-toast'
 import { formatCurrency } from '@/lib/utils'
-import { Plus, CreditCard, Banknote, Landmark, Send, CircleArrowDown, Trash2 } from 'lucide-react'
+import { Plus, CreditCard, Banknote, Landmark, Send, CircleArrowDown, Trash2, AlertTriangle } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -102,19 +102,32 @@ export function FinancialSidebar({ project, payments, summary, onPaymentAdded }:
   const remainingBalance = summary?.remaining_balance || 0
   const adjustedBudget = summary?.adjusted_budget || 0
   const collectedPct = summary?.collected_pct || 0
+  // Contract reconciliation: flag when the budget is a manual override that has
+  // drifted from the quote-derived total.
+  const contractOverridden = summary?.contract_overridden ?? false
+  const contractDrift = summary?.contract_drift || 0
+  const derivedContract = summary?.derived_contract_total ?? 0
+  const showDrift = contractOverridden && Math.abs(contractDrift) > 0.01
+  // Over-budget: collected has run past the contract budget. Split the bar into a
+  // green (within-budget) and a yellow (overage) segment, and say by how much.
+  const overBudget = adjustedBudget > 0 ? Math.max(0, totalPaid - adjustedBudget) : 0
+  const isOverBudget = overBudget > 0.01
+  const barDenom = isOverBudget ? totalPaid : adjustedBudget > 0 ? adjustedBudget : 1
+  const greenWidth = isOverBudget ? (adjustedBudget / barDenom) * 100 : Math.min(collectedPct, 100)
+  const yellowWidth = isOverBudget ? (overBudget / barDenom) * 100 : 0
 
   return (
     <div className="space-y-6">
       {/* 1. PAYMENTS RECEIVED CARD */}
       <Card className="border shadow-sm top-6 sticky">
-        <CardHeader className="bg-slate-50 border-b flex flex-row items-center justify-between pb-3 pt-4 px-4 sticky top-0 rounded-t-lg z-10">
-          <CardTitle className="text-sm font-bold uppercase tracking-wider text-slate-700">
+        <CardHeader className="bg-muted border-b flex flex-row items-center justify-between pb-3 pt-4 px-4 sticky top-0 rounded-t-lg z-10">
+          <CardTitle className="text-sm font-bold uppercase tracking-wider text-foreground">
             Payments Received
           </CardTitle>
           
           <Dialog open={openPaymentModal} onOpenChange={setOpenPaymentModal}>
             <DialogTrigger asChild>
-              <Button size="sm" className="h-8 bg-orange-500 hover:bg-orange-600 text-white transition-colors">
+              <Button size="sm" className="h-8 bg-primary hover:bg-primary/90 text-white transition-colors">
                 <Plus className="w-4 h-4 mr-1" /> Add
               </Button>
             </DialogTrigger>
@@ -126,13 +139,12 @@ export function FinancialSidebar({ project, payments, summary, onPaymentAdded }:
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label>Amount</Label>
-                    <Input 
-                      type="number" 
-                      step="0.01" 
-                      min="0"
-                      value={amount} 
-                      onChange={e => setAmount(e.target.value)} 
-                      required 
+                    <Input
+                      type="text"
+                      inputMode="decimal"
+                      value={amount}
+                      onChange={e => setAmount(e.target.value.replace(/[^0-9.]/g, ''))}
+                      required
                       placeholder="0.00"
                     />
                   </div>
@@ -182,7 +194,7 @@ export function FinancialSidebar({ project, payments, summary, onPaymentAdded }:
                 </div>
                 
                 <div className="flex justify-end pt-4">
-                  <Button type="submit" disabled={isSubmitting} className="bg-orange-500 hover:bg-orange-600">
+                  <Button type="submit" disabled={isSubmitting} className="bg-primary hover:bg-primary/90">
                     {isSubmitting ? 'Logging...' : 'Save Payment'}
                   </Button>
                 </div>
@@ -192,21 +204,21 @@ export function FinancialSidebar({ project, payments, summary, onPaymentAdded }:
         </CardHeader>
         
         <CardContent className="p-0">
-          <div className="p-4 space-y-4 bg-white">
+          <div className="p-4 space-y-4 bg-card">
             <div className="flex justify-between items-end">
               <div>
-                <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-1">Collected</p>
-                <p className="text-2xl font-bold text-emerald-600">{formatCurrency(totalPaid)}</p>
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-1">Collected</p>
+                <p className="text-2xl font-bold text-status-active">{formatCurrency(totalPaid)}</p>
               </div>
               <div className="text-right">
-                <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-1">Due</p>
-                <p className="text-lg font-bold text-orange-500">{formatCurrency(remainingBalance)}</p>
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-1">Due</p>
+                <p className="text-lg font-bold text-primary">{formatCurrency(remainingBalance)}</p>
               </div>
             </div>
 
             {/* Progress Bar */}
             <div className="space-y-1 mt-2">
-              <div className="flex justify-between text-xs font-medium text-slate-500">
+              <div className="flex justify-between text-xs font-medium text-muted-foreground">
                 <span className="tabular-nums">
                   {Number.isInteger(collectedPct) ? collectedPct : collectedPct.toFixed(1)}% collected
                 </span>
@@ -214,33 +226,54 @@ export function FinancialSidebar({ project, payments, summary, onPaymentAdded }:
                   <span className="tabular-nums">Budget {formatCurrency(adjustedBudget)}</span>
                 )}
               </div>
-              <div className="w-full bg-slate-100 rounded-full h-2 overflow-hidden">
-                <div 
-                  className="bg-emerald-500 h-2 rounded-full transition-all duration-500" 
-                  style={{ width: `${Math.min(collectedPct, 100)}%` }} 
+              <div className="flex w-full bg-muted rounded-full h-2 overflow-hidden">
+                <div
+                  className="bg-status-active h-2 transition-all duration-500"
+                  style={{ width: `${greenWidth}%` }}
                 />
+                {isOverBudget && (
+                  <div
+                    className="bg-status-pending h-2 transition-all duration-500"
+                    style={{ width: `${yellowWidth}%` }}
+                  />
+                )}
               </div>
+              {isOverBudget && (
+                <p className="text-[11px] font-medium text-status-pending tabular-nums">
+                  Over budget by {formatCurrency(overBudget)} ({Math.round((overBudget / adjustedBudget) * 100)}%)
+                </p>
+              )}
             </div>
+
+            {showDrift && (
+              <div className="flex items-start gap-1.5 rounded-md bg-status-pending/10 border border-status-pending/30 px-2.5 py-2 text-[11px] leading-snug text-status-pending">
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-px" />
+                <span>
+                  Budget is overridden — quote-derived total is {formatCurrency(derivedContract)}
+                  {' '}({contractDrift > 0 ? '+' : '−'}{formatCurrency(Math.abs(contractDrift))}).
+                </span>
+              </div>
+            )}
           </div>
 
-          <div className="divide-y border-t bg-slate-50/50">
+          <div className="divide-y border-t bg-muted/50">
             {payments.length === 0 ? (
-              <div className="p-5 text-center text-xs text-slate-400">No entries</div>
+              <div className="p-5 text-center text-xs text-muted-foreground">No entries</div>
             ) : (
               payments.map(payment => (
                 <div key={payment.id} className="p-4 flex items-center justify-between group">
                   <div className="flex items-start space-x-3">
-                    <div className="bg-white p-2 border rounded-md shadow-sm text-slate-500">
+                    <div className="bg-background p-2 border rounded-md shadow-sm text-muted-foreground">
                       {getMethodIcon(payment.payment_method)}
                     </div>
                     <div>
-                      <p className="text-sm font-semibold text-slate-800">{formatCurrency(payment.amount)}</p>
-                      <div className="text-xs text-slate-500 flex items-center space-x-2 mt-0.5">
+                      <p className="text-sm font-semibold text-foreground">{formatCurrency(payment.amount)}</p>
+                      <div className="text-xs text-muted-foreground flex items-center space-x-2 mt-0.5">
                         <span>{new Date(payment.payment_date).toLocaleDateString()}</span>
                         {payment.invoice_number && (
                           <>
-                            <span className="text-slate-300">•</span>
-                            <span className="font-medium text-slate-600">{payment.invoice_number}</span>
+                            <span className="text-muted-foreground">•</span>
+                            <span className="font-medium text-muted-foreground">{payment.invoice_number}</span>
                           </>
                         )}
                       </div>
@@ -249,7 +282,7 @@ export function FinancialSidebar({ project, payments, summary, onPaymentAdded }:
                   <Button 
                     variant="ghost" 
                     size="icon" 
-                    className="h-8 w-8 text-slate-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                    className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
                     onClick={() => handleDeletePayment(payment.id)}
                   >
                     <Trash2 className="h-4 w-4" />

--- a/components/projects/financials/job-costing-tab.tsx
+++ b/components/projects/financials/job-costing-tab.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Project, ProjectCostItem, CostItemStatus } from '@/lib/types'
+import { Project, ProjectCostItem, CostItemStatus, ScopeQuoteLineItem } from '@/lib/types'
 import { api } from '@/lib/api'
+import { QuoteItemPicker } from './quote-item-picker'
 import { useAuth } from '@/contexts/AuthContext'
 import { useToast } from '@/components/ui/use-toast'
 import { formatCurrency } from '@/lib/utils'
-import { 
+import {
   Accordion,
   AccordionContent,
   AccordionItem,
@@ -18,13 +19,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Card, CardContent } from '@/components/ui/card'
+import { MoneyInput } from './money-input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Badge } from '@/components/ui/badge'
-import { Trash2, Plus, Loader2, Save } from 'lucide-react'
+import { Trash2, Plus, Loader2, FileDown } from 'lucide-react'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
@@ -32,6 +35,8 @@ interface JobCostingTabProps {
   project: Project
   onRefreshTotal: () => void
 }
+
+const pct = (n: number) => `${Math.round(n)}%`
 
 export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
   const { toast } = useToast()
@@ -54,23 +59,40 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
     }
   }
 
+  // Build the trade-derived sub list (subs already assigned to a project trade).
+  // Used as a defensive merge + as the fallback if the directory call fails.
+  const tradeSubsMap = () => {
+    const m = new Map<number, { id: number; name: string }>()
+    project.trades?.forEach(trade => {
+      if (trade.subcontractor_id && !m.has(trade.subcontractor_id)) {
+        m.set(trade.subcontractor_id, {
+          id: trade.subcontractor_id,
+          name: trade.subcontractor_name || trade.trade_type,
+        })
+      }
+    })
+    return m
+  }
+
   const loadSubs = async () => {
     try {
-      if (project.trades && project.trades.length > 0) {
-        const uniqueSubs = new Map()
-        project.trades.forEach(trade => {
-          if (trade.subcontractor_id) {
-            if (!uniqueSubs.has(trade.subcontractor_id)) {
-              uniqueSubs.set(trade.subcontractor_id, {
-                id: trade.subcontractor_id,
-                name: trade.subcontractor_name || trade.trade_type
-              })
-            }
-          }
-        })
-        setSubs(Array.from(uniqueSubs.values()))
-      }
-    } catch(e) {}
+      // Primary source: the contractor's full subcontractor directory. A cost
+      // item's `subcontractor_id` is an FK to `subcontractors.id`, so the dropdown
+      // must list the whole directory — not only subs already assigned to a trade
+      // (the old behaviour, which left the dropdown at just "Unassigned" whenever
+      // no trade had a sub assigned yet).
+      const directory = await api.getSubcontractors(0, 500)
+      const byId = tradeSubsMap()
+      ;(directory || []).forEach((s: any) => {
+        if (s?.id != null) {
+          byId.set(s.id, { id: s.id, name: s.name || s.company_name || `Sub #${s.id}` })
+        }
+      })
+      setSubs(Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name)))
+    } catch (e) {
+      // Directory unavailable — fall back to subs referenced by project trades.
+      setSubs(Array.from(tradeSubsMap().values()))
+    }
   }
 
   useEffect(() => {
@@ -90,7 +112,7 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
     try {
       const updated = await api.updateProjectCostItem(project.id, itemId, updates)
       setItems(prev => prev.map(i => i.id === itemId ? (updated as ProjectCostItem) : i))
-      
+
       // If cost/markup changed, it might affect the total summary
       if (updates.gc_cost !== undefined || updates.client_price !== undefined || updates.paid !== undefined) {
         onRefreshTotal()
@@ -122,6 +144,41 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null)
   const [deletingItemId, setDeletingItemId] = useState<number | null>(null)
+  const [quotePickerPhase, setQuotePickerPhase] = useState<string | null>(null)
+
+  // Quote line items already pulled into this tab — so the picker can mark them.
+  const pulledItemIds = new Set(
+    items.map((i) => i.source_job_item_id).filter((x): x is number => x != null)
+  )
+
+  // Seed cost lines from selected quote line items (cost → gc_cost, price → client_price).
+  const handleAddFromQuote = async (phase: string, lineItems: ScopeQuoteLineItem[]) => {
+    // Create sequentially and commit whatever succeeded — even if a later item fails —
+    // so already-persisted rows appear immediately (and are deduped on re-open).
+    // Rethrow on failure so the picker stays open instead of closing on a partial save.
+    const created: ProjectCostItem[] = []
+    try {
+      for (const li of lineItems) {
+        const newItem = await api.createProjectCostItem(project.id, {
+          phase,
+          line_item: li.description,
+          gc_cost: li.cost,
+          client_price: li.total,
+          source_job_item_id: li.id,
+        })
+        created.push(newItem as ProjectCostItem)
+      }
+      toast({ title: `Added ${created.length} item${created.length === 1 ? '' : 's'} from quote` })
+    } catch (err: any) {
+      toast({ title: 'Error adding from quote', description: err.message, variant: 'destructive' })
+      throw err
+    } finally {
+      if (created.length) {
+        setItems((prev) => [...prev, ...created])
+        onRefreshTotal()
+      }
+    }
+  }
 
   const openCreateDialog = (type: 'phase' | 'item', phaseContext?: string) => {
     setCreateDialogType(type)
@@ -133,7 +190,7 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
   const handleCreateSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!newItemName.trim()) return
-    
+
     try {
       setIsSubmitting(true)
       const phaseToUse = createDialogType === 'phase' ? newItemName.trim().toUpperCase() : createDialogPhase
@@ -156,11 +213,11 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
 
   const getStatusColor = (status: CostItemStatus) => {
     switch (status) {
-      case 'COMPLETED': return 'bg-slate-800 text-white'
-      case 'GC_APPROVED': return 'bg-emerald-500 text-white'
-      case 'IN_PROGRESS': return 'bg-orange-500 text-white'
-      case 'SCHEDULED': return 'bg-yellow-500 text-white'
-      default: return 'bg-slate-200 text-slate-800'
+      case 'COMPLETED': return 'bg-foreground/10 text-foreground'
+      case 'GC_APPROVED': return 'bg-status-active/15 text-status-active'
+      case 'IN_PROGRESS': return 'bg-primary/15 text-primary'
+      case 'SCHEDULED': return 'bg-status-pending/15 text-status-pending'
+      default: return 'bg-muted text-muted-foreground'
     }
   }
 
@@ -170,62 +227,112 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
   const totalGcCost = items.reduce((acc, i) => acc + Number(i.gc_cost), 0)
   const totalClientPrice = items.reduce((acc, i) => acc + Number(i.client_price), 0)
   const totalPaid = items.reduce((acc, i) => acc + Number(i.paid), 0)
+  const totalProfit = totalClientPrice - totalGcCost
+  const margin = totalClientPrice > 0 ? (totalProfit / totalClientPrice) * 100 : 0
+  const paidPct = totalGcCost > 0 ? Math.max(0, Math.min(100, (totalPaid / totalGcCost) * 100)) : 0
+  const owedRemaining = Math.max(0, totalGcCost - totalPaid)
 
   const phasesToRender = Object.keys(groupedItems)
 
   return (
-    <div className="p-0">
-      <div className="flex justify-between items-center p-4 border-b">
-        <h2 className="text-lg font-bold text-slate-800">Job Costing (Labour & Subs)</h2>
-        <Button size="sm" onClick={() => openCreateDialog('phase')} className="bg-slate-800 text-white hover:bg-slate-700">
+    <div className="p-4 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-sm font-bold uppercase tracking-wider text-foreground">Job Costing · Labour &amp; Subs</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">What you pay subs &amp; labour vs. what the client is billed.</p>
+        </div>
+        <Button size="sm" onClick={() => openCreateDialog('phase')} className="shrink-0">
           <Plus className="w-4 h-4 mr-1" /> Add Phase
         </Button>
       </div>
 
+      {/* Summary headline */}
+      {items.length > 0 && (
+        <Card className="border shadow-sm">
+          <CardContent className="p-5 space-y-4">
+            <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+              <div className="rounded-lg border bg-card px-3 py-2.5">
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground truncate">{companyName} Cost</p>
+                <p className="text-lg font-bold tabular-nums leading-tight text-foreground">{formatCurrency(totalGcCost)}</p>
+              </div>
+              <div className="rounded-lg border bg-card px-3 py-2.5">
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Client Price</p>
+                <p className="text-lg font-bold tabular-nums leading-tight text-primary">{formatCurrency(totalClientPrice)}</p>
+              </div>
+              <div className="rounded-lg border bg-card px-3 py-2.5">
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Profit · {pct(margin)} margin</p>
+                <p className={`text-lg font-bold tabular-nums leading-tight ${totalProfit >= 0 ? 'text-status-active' : 'text-destructive'}`}>{formatCurrency(totalProfit)}</p>
+              </div>
+              <div className="rounded-lg border bg-card px-3 py-2.5">
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Paid to subs</p>
+                <p className="text-lg font-bold tabular-nums leading-tight text-foreground">{formatCurrency(totalPaid)}</p>
+              </div>
+            </div>
+            {/* How much of what you owe subs has been paid out */}
+            <div className="space-y-1.5">
+              <div className="flex w-full h-2 overflow-hidden rounded-full bg-muted">
+                <div className="bg-status-active transition-all duration-500" style={{ width: `${paidPct}%` }} />
+              </div>
+              <div className="flex flex-wrap justify-between gap-x-4 text-[11px] font-medium text-muted-foreground">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 rounded-full bg-status-active" /> {pct(paidPct)} of cost paid to subs
+                </span>
+                {owedRemaining > 0.01 && <span className="tabular-nums">{formatCurrency(owedRemaining)} still owed</span>}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {phasesToRender.length === 0 && (
-        <div className="text-center py-12 px-4 border border-dashed rounded-lg bg-slate-50 mt-4">
-          <p className="text-slate-500 mb-4 font-medium">No phases or line items have been added to this project yet.</p>
-          <Button onClick={() => openCreateDialog('phase')} className="bg-orange-500 hover:bg-orange-600 text-white">
+        <div className="text-center py-12 px-4 border border-dashed rounded-lg bg-muted">
+          <p className="text-muted-foreground mb-4 font-medium">No phases or line items have been added to this project yet.</p>
+          <Button onClick={() => openCreateDialog('phase')} className="bg-primary hover:bg-primary/90 text-white">
             <Plus className="w-4 h-4 mr-2" /> Create Your First Phase
           </Button>
         </div>
       )}
 
-      <Accordion type="multiple" defaultValue={phasesToRender} className="w-full mt-4">
+      <Accordion type="multiple" defaultValue={phasesToRender} className="w-full">
         {phasesToRender.map(phase => {
           const phaseItems = groupedItems[phase] || []
           const phaseTotal = phaseItems.reduce((acc, i) => acc + Number(i.client_price), 0)
+          const phaseCost = phaseItems.reduce((acc, i) => acc + Number(i.gc_cost), 0)
 
           return (
-            <AccordionItem key={phase} value={phase} className="px-4">
-              <AccordionTrigger className="hover:no-underline py-4">
-                <div className="flex justify-between items-center w-full pr-4">
-                  <span className="font-bold text-slate-700 tracking-wide uppercase text-sm">
-                    {phase} <span className="text-slate-400 font-normal ml-2">({phaseItems.length} items)</span>
+            <AccordionItem key={phase} value={phase} className="border rounded-lg mb-3 px-4 last:mb-0">
+              <AccordionTrigger className="hover:no-underline py-3">
+                <div className="flex justify-between items-center w-full pr-4 gap-3">
+                  <span className="font-bold text-foreground tracking-wide uppercase text-sm truncate">
+                    {phase} <span className="text-muted-foreground font-normal ml-1">· {phaseItems.length} item{phaseItems.length === 1 ? '' : 's'}</span>
                   </span>
-                  <span className="font-bold text-orange-600">{formatCurrency(phaseTotal)}</span>
+                  <span className="flex items-center gap-3 shrink-0">
+                    <span className="hidden sm:inline text-xs text-muted-foreground tabular-nums">cost {formatCurrency(phaseCost)}</span>
+                    <span className="font-bold text-primary tabular-nums">{formatCurrency(phaseTotal)}</span>
+                  </span>
                 </div>
               </AccordionTrigger>
-              <AccordionContent className="pb-6">
+              <AccordionContent className="pb-5">
                 <div className="rounded-md border overflow-hidden">
                   <Table className="table-fixed w-full">
-                    <TableHeader className="bg-slate-50">
+                    <TableHeader className="bg-muted">
                       <TableRow>
-                        <TableHead className="w-[28%] text-sm">Line Item</TableHead>
-                        <TableHead className="w-[14%] text-right text-sm">{companyName} Cost</TableHead>
-                        <TableHead className="w-[14%] text-right text-sm font-bold text-slate-800">Client Price</TableHead>
-                        <TableHead className="w-[14%] text-right text-sm">Paid</TableHead>
-                        <TableHead className="w-[13%] text-center text-sm">Status</TableHead>
-                        <TableHead className="w-[14%] text-right text-sm">Subcontractor</TableHead>
+                        <TableHead className="w-[28%] text-xs uppercase tracking-wider">Line Item</TableHead>
+                        <TableHead className="w-[14%] text-right text-xs uppercase tracking-wider">{companyName} Cost</TableHead>
+                        <TableHead className="w-[14%] text-right text-xs uppercase tracking-wider font-bold text-foreground">Client Price</TableHead>
+                        <TableHead className="w-[14%] text-right text-xs uppercase tracking-wider">Paid</TableHead>
+                        <TableHead className="w-[13%] text-center text-xs uppercase tracking-wider">Status</TableHead>
+                        <TableHead className="w-[14%] text-right text-xs uppercase tracking-wider">Subcontractor</TableHead>
                         <TableHead className="w-[3%]"></TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
                       {phaseItems.map(item => (
-                        <TableRow key={item.id} className="group hover:bg-slate-50 border-b">
-                          <TableCell className="font-medium text-slate-700 align-top pt-2 min-w-0 text-sm">
-                            <Textarea 
-                              className="border-transparent hover:border-slate-200 bg-transparent min-h-[28px] h-auto p-1 text-sm shadow-none focus-visible:ring-1 w-full resize-none overflow-hidden leading-snug whitespace-pre-wrap [overflow-wrap:anywhere]" 
+                        <TableRow key={item.id} className="group hover:bg-muted border-b">
+                          <TableCell className="font-medium text-foreground align-top pt-2 min-w-0 text-sm">
+                            <Textarea
+                              className="border-border/40 hover:border-border bg-transparent min-h-[28px] h-auto p-1 text-sm shadow-none focus-visible:ring-1 w-full resize-none overflow-hidden leading-snug whitespace-pre-wrap [overflow-wrap:anywhere]"
                               defaultValue={item.line_item}
                               rows={1}
                               ref={(el) => {
@@ -242,53 +349,41 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
                           </TableCell>
 
                           <TableCell className="text-right align-top text-sm">
-                            <Input 
-                              type="number" 
-                              className="w-full h-7 px-1.5 text-sm text-right bg-transparent border-transparent hover:border-slate-200 shadow-none focus-visible:ring-1" 
-                              defaultValue={item.gc_cost.toString()} 
-                              onBlur={(e) => {
-                                if(Number(e.target.value) !== item.gc_cost) 
-                                  handleUpdateItem(item.id, { gc_cost: Number(e.target.value) })
-                              }}
+                            <MoneyInput
+                              value={item.gc_cost}
+                              onCommit={(n) => handleUpdateItem(item.id, { gc_cost: n })}
+                              className="w-full h-7 px-1.5 text-sm text-right bg-transparent border-border/40 hover:border-border shadow-none focus-visible:ring-1"
                             />
-                            <div className="mt-1 text-left text-[10px] font-medium text-emerald-600">
+                            <div className="mt-1 text-left text-[10px] font-medium text-status-active">
                               Profit: {formatCurrency(Number(item.client_price) - Number(item.gc_cost))}
                             </div>
                           </TableCell>
 
                           <TableCell className="text-right text-sm">
-                            <Input 
-                              type="number" 
-                              className="w-full h-7 px-1.5 text-sm text-right font-bold text-slate-800 bg-transparent border-transparent hover:border-slate-200 shadow-none focus-visible:ring-1" 
-                              defaultValue={item.client_price.toString()} 
-                              onBlur={(e) => {
-                                if(Number(e.target.value) !== item.client_price) 
-                                  handleUpdateItem(item.id, { client_price: Number(e.target.value) })
-                              }}
+                            <MoneyInput
+                              value={item.client_price}
+                              onCommit={(n) => handleUpdateItem(item.id, { client_price: n })}
+                              className="w-full h-7 px-1.5 text-sm text-right font-bold text-foreground bg-transparent border-border/40 hover:border-border shadow-none focus-visible:ring-1"
                             />
                           </TableCell>
 
                           <TableCell className="text-right align-top text-sm">
-                            <Input 
-                              type="number" 
-                              className={`w-full h-7 px-1.5 text-sm text-right font-semibold bg-transparent border-transparent hover:border-slate-200 shadow-none focus-visible:ring-1 ${item.paid >= item.gc_cost && item.gc_cost > 0 ? 'text-emerald-600 bg-emerald-50/50' : 'text-slate-700'}`}
-                              defaultValue={item.paid.toString()} 
-                              onBlur={(e) => {
-                                if(Number(e.target.value) !== item.paid) 
-                                  handleUpdateItem(item.id, { paid: Number(e.target.value) })
-                              }}
+                            <MoneyInput
+                              value={item.paid}
+                              onCommit={(n) => handleUpdateItem(item.id, { paid: n })}
+                              className={`w-full h-7 px-1.5 text-sm text-right font-semibold bg-transparent border-border/40 hover:border-border shadow-none focus-visible:ring-1 ${item.paid >= item.gc_cost && item.gc_cost > 0 ? 'text-status-active bg-status-active/10' : 'text-foreground'}`}
                             />
-                            <div className="mt-1 text-left text-[10px] font-medium text-red-600">
+                            <div className="mt-1 text-left text-[10px] font-medium text-destructive">
                               Unpaid: ({formatCurrency(Math.max(Number(item.client_price) - Number(item.paid), 0))})
                             </div>
                           </TableCell>
 
                           <TableCell className="px-1.5">
-                            <Select 
+                            <Select
                               value={item.status}
                               onValueChange={(val) => handleUpdateItem(item.id, { status: val })}
                             >
-                              <SelectTrigger className={`h-7 min-h-0 text-[10px] w-full border-transparent hover:border-slate-200 shadow-none bg-transparent font-semibold justify-center px-1 [&_svg]:hidden ${getStatusColor(item.status)}`}>
+                              <SelectTrigger className={`h-7 min-h-0 text-[10px] w-full border-border/40 hover:border-border shadow-none bg-transparent font-semibold justify-center px-1 [&_svg]:hidden ${getStatusColor(item.status)}`}>
                                 <SelectValue />
                               </SelectTrigger>
                               <SelectContent>
@@ -301,11 +396,11 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
                           </TableCell>
 
                           <TableCell className="text-right">
-                            <Select 
+                            <Select
                               value={item.subcontractor_id?.toString() || 'unassigned'}
                               onValueChange={(val) => handleUpdateItem(item.id, { subcontractor_id: val === 'unassigned' ? null : Number(val)})}
                             >
-                              <SelectTrigger className="h-7 text-[10px] w-full px-2 border-dashed bg-transparent shadow-none hover:border-slate-300">
+                              <SelectTrigger className="h-7 text-[10px] w-full px-2 border-dashed bg-transparent shadow-none hover:border-border">
                                 <SelectValue placeholder="Unassigned" />
                               </SelectTrigger>
                               <SelectContent>
@@ -325,16 +420,16 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
                               onOpenChange={(open) => setDeleteConfirmId(open ? item.id : null)}
                             >
                               <PopoverTrigger asChild>
-                                <Button 
-                                  variant="ghost" 
-                                  size="icon" 
-                                  className="h-7 w-7 text-slate-400 hover:text-red-500 opacity-0 group-hover:opacity-100"
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100"
                                 >
                                   <Trash2 className="w-4 h-4" />
                                 </Button>
                               </PopoverTrigger>
                               <PopoverContent side="top" align="end" className="w-52 p-3">
-                                <p className="mb-2 text-xs text-slate-700">Delete this line item?</p>
+                                <p className="mb-2 text-xs text-foreground">Delete this line item?</p>
                                 <div className="flex justify-end gap-2">
                                   <Button
                                     variant="outline"
@@ -346,7 +441,7 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
                                   </Button>
                                   <Button
                                     size="sm"
-                                    className="h-7 px-2 text-xs bg-red-600 hover:bg-red-700 text-white"
+                                    className="h-7 px-2 text-xs bg-destructive hover:bg-destructive/90 text-white"
                                     disabled={deletingItemId === item.id}
                                     onClick={() => handleDeleteItem(item.id)}
                                   >
@@ -360,15 +455,18 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
                       ))}
                       {phaseItems.length === 0 && (
                         <TableRow>
-                          <TableCell colSpan={8} className="text-center text-slate-400 py-6 italic">No items in this phase.</TableCell>
+                          <TableCell colSpan={8} className="text-center text-muted-foreground py-6 italic">No items in this phase.</TableCell>
                         </TableRow>
                       )}
                     </TableBody>
                   </Table>
                 </div>
-                <div className="mt-3">
-                  <Button variant="outline" size="sm" onClick={() => openCreateDialog('item', phase)} className="text-orange-600 border-orange-200 hover:bg-orange-50 font-medium">
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button variant="outline" size="sm" onClick={() => openCreateDialog('item', phase)} className="text-primary border-primary/30 hover:bg-primary/10 font-medium">
                     <Plus className="w-4 h-4 mr-1" /> Add Line Item to {phase}
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => setQuotePickerPhase(phase)} className="text-muted-foreground border-border hover:bg-muted font-medium">
+                    <FileDown className="w-4 h-4 mr-1" /> From quote
                   </Button>
                 </div>
               </AccordionContent>
@@ -376,24 +474,6 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
           )
         })}
       </Accordion>
-
-      <div className="bg-slate-900 text-white p-4 flex flex-col gap-3 rounded-b-lg mt-4 shadow-inner lg:flex-row lg:justify-between lg:items-center">
-        <h3 className="font-bold tracking-widest text-sm text-slate-300">TOTAL PROJECT SUBS</h3>
-        <div className="flex flex-wrap gap-x-8 gap-y-2 text-sm lg:justify-end">
-          <div className="text-right">
-            <span className="text-slate-400 mr-2 text-xs">Total {companyName} Cost</span>
-            <span className="font-semibold">{formatCurrency(totalGcCost)}</span>
-          </div>
-          <div className="text-right">
-            <span className="text-slate-400 mr-2 text-xs">Client Price</span>
-            <span className="font-bold text-orange-400">{formatCurrency(totalClientPrice)}</span>
-          </div>
-          <div className="text-right border-l border-slate-700 pl-6">
-            <span className="text-slate-400 mr-2 text-xs">Total Paid</span>
-            <span className="font-semibold text-emerald-400">{formatCurrency(totalPaid)}</span>
-          </div>
-        </div>
-      </div>
 
       <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
         <DialogContent className="sm:max-w-[425px]">
@@ -405,7 +485,7 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
           <form onSubmit={handleCreateSubmit} className="space-y-4 pt-4">
             <div className="space-y-2">
               <Label>{createDialogType === 'phase' ? 'Phase Name' : 'Line Item Title'}</Label>
-              <Input 
+              <Input
                 value={newItemName}
                 onChange={e => setNewItemName(e.target.value)}
                 placeholder={createDialogType === 'phase' ? 'e.g. FRAMING' : 'e.g. Rough Lumber / Labor'}
@@ -414,13 +494,24 @@ export function JobCostingTab({ project, onRefreshTotal }: JobCostingTabProps) {
               />
             </div>
             <div className="flex justify-end pt-4">
-              <Button type="submit" disabled={isSubmitting} className="bg-orange-500 hover:bg-orange-600">
+              <Button type="submit" disabled={isSubmitting} className="bg-primary hover:bg-primary/90">
                 {isSubmitting ? 'Saving...' : 'Save'}
               </Button>
             </div>
           </form>
         </DialogContent>
       </Dialog>
+
+      {quotePickerPhase && (
+        <QuoteItemPicker
+          projectId={project.id}
+          open={!!quotePickerPhase}
+          onOpenChange={(o) => { if (!o) setQuotePickerPhase(null) }}
+          pulledItemIds={pulledItemIds}
+          destinationLabel={`${quotePickerPhase} phase`}
+          onConfirm={(lineItems) => handleAddFromQuote(quotePickerPhase, lineItems)}
+        />
+      )}
     </div>
   )
 }

--- a/components/projects/financials/materials-permits-tab.tsx
+++ b/components/projects/financials/materials-permits-tab.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { Project, ProjectMaterial } from '@/lib/types'
+import { Project, ProjectMaterial, ScopeQuoteLineItem } from '@/lib/types'
 import { api } from '@/lib/api'
+import { QuoteItemPicker } from './quote-item-picker'
 import { useToast } from '@/components/ui/use-toast'
 import { formatCurrency } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { MoneyInput } from './money-input'
 import {
   Dialog,
   DialogContent,
@@ -14,7 +16,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
-import { Trash2, Plus, Loader2, Link2, Eye, Upload } from 'lucide-react'
+import { Trash2, Plus, Loader2, Link2, Eye, Upload, FileDown } from 'lucide-react'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
@@ -172,6 +174,45 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
     setCreateDialogOpen(true)
   }
 
+  const [quotePickerCategory, setQuotePickerCategory] = useState<'JOB_MATERIAL' | 'SITE_SERVICE' | null>(null)
+
+  // Quote line items already pulled into materials — so the picker can mark them.
+  const pulledItemIds = new Set(
+    items.map((i) => i.source_job_item_id).filter((x): x is number => x != null)
+  )
+
+  // Seed material lines from selected quote line items (cost → cost, price → client_price).
+  const handleAddFromQuote = async (
+    category: 'JOB_MATERIAL' | 'SITE_SERVICE',
+    lineItems: ScopeQuoteLineItem[],
+  ) => {
+    // Create sequentially and commit whatever succeeded — even if a later item fails —
+    // so already-persisted rows appear immediately (and are deduped on re-open).
+    // Rethrow on failure so the picker stays open instead of closing on a partial save.
+    const created: ProjectMaterial[] = []
+    try {
+      for (const li of lineItems) {
+        const newItem = await api.createProjectMaterial(project.id, {
+          category,
+          item_name: li.description,
+          cost: li.cost,
+          client_price: li.total,
+          source_job_item_id: li.id,
+        })
+        created.push(newItem as ProjectMaterial)
+      }
+      toast({ title: `Added ${created.length} item${created.length === 1 ? '' : 's'} from quote` })
+    } catch (err: any) {
+      toast({ title: 'Error adding from quote', description: err.message, variant: 'destructive' })
+      throw err
+    } finally {
+      if (created.length) {
+        setItems((prev) => [...prev, ...created])
+        onRefreshTotal()
+      }
+    }
+  }
+
   const handleCreateSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!newItemName.trim()) return
@@ -206,31 +247,36 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
       {/* JOB MATERIALS */}
       <div className="p-6">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-bold text-slate-800 tracking-tight">Job Materials</h2>
-          <Button size="sm" onClick={() => openCreateDialog('JOB_MATERIAL')} className="bg-orange-500 hover:bg-orange-600">
-            <Plus className="w-4 h-4 mr-1" /> Add Material
-          </Button>
+          <h2 className="text-lg font-bold text-foreground tracking-tight">Job Materials</h2>
+          <div className="flex gap-2">
+            <Button size="sm" variant="outline" onClick={() => setQuotePickerCategory('JOB_MATERIAL')} className="text-muted-foreground border-border hover:bg-muted">
+              <FileDown className="w-4 h-4 mr-1" /> From quote
+            </Button>
+            <Button size="sm" onClick={() => openCreateDialog('JOB_MATERIAL')} className="bg-primary hover:bg-primary/90">
+              <Plus className="w-4 h-4 mr-1" /> Add Material
+            </Button>
+          </div>
         </div>
         
         <div className="rounded-lg border overflow-hidden">
           <Table>
-            <TableHeader className="bg-slate-50">
+            <TableHeader className="bg-muted">
               <TableRow>
                 <TableHead className="w-[200px]">Item</TableHead>
                 <TableHead>Vendor</TableHead>
                 <TableHead>Detailed Notes</TableHead>
                 <TableHead className="text-right">Cost</TableHead>
-                <TableHead className="text-right font-bold text-slate-700">Client Price</TableHead>
+                <TableHead className="text-right font-bold text-foreground">Client Price</TableHead>
                 <TableHead className="w-[100px] text-center">PO / Receipt</TableHead>
                 <TableHead className="w-[50px]"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {jobMaterials.map(item => (
-                <TableRow key={item.id} className="group hover:bg-slate-50 border-b">
-                  <TableCell className="font-medium text-slate-800">
+                <TableRow key={item.id} className="group hover:bg-muted border-b">
+                  <TableCell className="font-medium text-foreground">
                     <Input 
-                      className="border-transparent hover:border-slate-200 bg-transparent h-8 shadow-none focus-visible:ring-1" 
+                      className="border-border/40 hover:border-border bg-transparent h-8 shadow-none focus-visible:ring-1" 
                       defaultValue={item.item_name}
                       onBlur={e => { if(e.target.value !== item.item_name) handleUpdate(item.id, { item_name: e.target.value }) }}
                     />
@@ -238,7 +284,7 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                   <TableCell>
                     <Input 
                       placeholder="e.g. Home Depot"
-                      className="border-transparent hover:border-slate-200 bg-transparent h-8 shadow-none text-sm" 
+                      className="border-border/40 hover:border-border bg-transparent h-8 shadow-none text-sm" 
                       defaultValue={item.vendor || ''}
                       onBlur={e => { if(e.target.value !== item.vendor) handleUpdate(item.id, { vendor: e.target.value }) }}
                     />
@@ -246,29 +292,23 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                   <TableCell>
                     <Input 
                       placeholder="Details..."
-                      className="border-transparent hover:border-slate-200 bg-transparent h-8 shadow-none text-sm text-slate-500" 
+                      className="border-border/40 hover:border-border bg-transparent h-8 shadow-none text-sm text-muted-foreground" 
                       defaultValue={item.detailed_notes || ''}
                       onBlur={e => { if(e.target.value !== item.detailed_notes) handleUpdate(item.id, { detailed_notes: e.target.value }) }}
                     />
                   </TableCell>
                   <TableCell className="text-right">
-                    <Input 
-                      type="number" 
-                      className="w-24 h-8 text-right ml-auto" 
-                      defaultValue={item.cost.toString()} 
-                      onBlur={(e) => {
-                        if(Number(e.target.value) !== item.cost) handleUpdate(item.id, { cost: Number(e.target.value) })
-                      }}
+                    <MoneyInput
+                      value={item.cost}
+                      onCommit={(n) => handleUpdate(item.id, { cost: n })}
+                      className="w-24 h-8 text-right ml-auto"
                     />
                   </TableCell>
                   <TableCell className="text-right">
-                    <Input 
-                      type="number" 
-                      className="w-24 h-8 text-right font-bold text-slate-800 ml-auto" 
-                      defaultValue={item.client_price.toString()} 
-                      onBlur={(e) => {
-                        if(Number(e.target.value) !== item.client_price) handleUpdate(item.id, { client_price: Number(e.target.value) })
-                      }}
+                    <MoneyInput
+                      value={item.client_price}
+                      onCommit={(n) => handleUpdate(item.id, { client_price: n })}
+                      className="w-24 h-8 text-right font-bold text-foreground ml-auto"
                     />
                   </TableCell>
                   <TableCell className="text-center">
@@ -280,7 +320,7 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                         <Button
                           variant="ghost"
                           size="icon"
-                          className={`h-8 w-8 hover:bg-orange-50 ${getReceipts(item).length > 0 ? 'text-emerald-600 hover:text-emerald-700' : 'text-orange-500 hover:text-orange-600'}`}
+                          className={`h-8 w-8 hover:bg-primary/10 ${getReceipts(item).length > 0 ? 'text-status-active hover:text-status-active' : 'text-primary hover:text-primary'}`}
                           disabled={uploadingReceiptItemId === item.id}
                           title={getReceipts(item).length > 0 ? `${getReceipts(item).length} receipt(s) attached` : 'Attach receipt'}
                         >
@@ -292,7 +332,7 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                           {getReceipts(item).length > 0 && (
                             <div className="mb-2 space-y-1 max-h-48 overflow-y-auto pr-1">
                               {getReceipts(item).map((receipt, idx) => (
-                                <div key={idx} className="flex items-center justify-between gap-1 p-1 rounded hover:bg-slate-100 group">
+                                <div key={idx} className="flex items-center justify-between gap-1 p-1 rounded hover:bg-muted group">
                                   <Button
                                     variant="ghost"
                                     size="sm"
@@ -300,13 +340,13 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                                     onClick={() => setPreviewAttachment(receipt)}
                                     title={receipt.name}
                                   >
-                                    <Eye className="w-3.5 h-3.5 mr-2 shrink-0 text-slate-400 group-hover:text-emerald-600" />
+                                    <Eye className="w-3.5 h-3.5 mr-2 shrink-0 text-muted-foreground group-hover:text-status-active" />
                                     <span className="truncate">{receipt.name}</span>
                                   </Button>
                                   <Button
                                     variant="ghost"
                                     size="icon"
-                                    className="h-6 w-6 shrink-0 text-slate-400 hover:text-red-500 opacity-0 group-hover:opacity-100 hover:bg-red-50"
+                                    className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 hover:bg-destructive/10"
                                     onClick={() => handleDeleteReceipt(item, idx)}
                                   >
                                     <Trash2 className="w-3.5 h-3.5" />
@@ -337,13 +377,13 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                         <Button
                           variant="ghost"
                           size="icon"
-                          className="h-8 w-8 text-slate-400 hover:text-red-500 opacity-0 group-hover:opacity-100"
+                          className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100"
                         >
                           <Trash2 className="w-4 h-4" />
                         </Button>
                       </PopoverTrigger>
                       <PopoverContent side="top" align="end" className="w-52 p-3">
-                        <p className="mb-2 text-xs text-slate-700">Delete this material?</p>
+                        <p className="mb-2 text-xs text-foreground">Delete this material?</p>
                         <div className="flex justify-end gap-2">
                           <Button
                             variant="outline"
@@ -355,7 +395,7 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                           </Button>
                           <Button
                             size="sm"
-                            className="h-7 px-2 text-xs bg-red-600 hover:bg-red-700 text-white"
+                            className="h-7 px-2 text-xs bg-destructive hover:bg-destructive/90 text-white"
                             disabled={deletingItemId === item.id}
                             onClick={() => handleDelete(item.id)}
                           >
@@ -369,7 +409,7 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
               ))}
               {jobMaterials.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-center text-slate-400 py-6 italic">No materials added.</TableCell>
+                  <TableCell colSpan={8} className="text-center text-muted-foreground py-6 italic">No materials added.</TableCell>
                 </TableRow>
               )}
             </TableBody>
@@ -380,29 +420,34 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
       {/* SITE SERVICES & PERMITS */}
       <div className="p-6 pt-0">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-bold text-slate-800 tracking-tight">Site Services & Admin (Permits, Utilities)</h2>
-          <Button size="sm" onClick={() => openCreateDialog('SITE_SERVICE')} variant="outline" className="text-orange-600 border-orange-200 hover:bg-orange-50">
-            <Plus className="w-4 h-4 mr-1" /> Add Service
-          </Button>
+          <h2 className="text-lg font-bold text-foreground tracking-tight">Site Services & Admin (Permits, Utilities)</h2>
+          <div className="flex gap-2">
+            <Button size="sm" variant="outline" onClick={() => setQuotePickerCategory('SITE_SERVICE')} className="text-muted-foreground border-border hover:bg-muted">
+              <FileDown className="w-4 h-4 mr-1" /> From quote
+            </Button>
+            <Button size="sm" onClick={() => openCreateDialog('SITE_SERVICE')} variant="outline" className="text-primary border-primary/30 hover:bg-primary/10">
+              <Plus className="w-4 h-4 mr-1" /> Add Service
+            </Button>
+          </div>
         </div>
         
         <div className="rounded-lg border overflow-hidden">
           <Table>
-            <TableHeader className="bg-slate-100">
+            <TableHeader className="bg-muted">
               <TableRow>
                 <TableHead>Service / Permit Name</TableHead>
                 <TableHead>Agency / Vendor</TableHead>
                 <TableHead className="text-right">Cost</TableHead>
-                <TableHead className="text-right font-bold text-slate-700">Client Price</TableHead>
+                <TableHead className="text-right font-bold text-foreground">Client Price</TableHead>
                 <TableHead className="w-[50px]"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {siteServices.map(item => (
-                <TableRow key={item.id} className="group hover:bg-slate-50 border-b">
+                <TableRow key={item.id} className="group hover:bg-muted border-b">
                   <TableCell className="font-medium">
                     <Input 
-                      className="border-transparent hover:border-slate-200 bg-transparent h-8 shadow-none font-medium text-slate-700" 
+                      className="border-border/40 hover:border-border bg-transparent h-8 shadow-none font-medium text-foreground" 
                       defaultValue={item.item_name}
                       onBlur={e => { if(e.target.value !== item.item_name) handleUpdate(item.id, { item_name: e.target.value }) }}
                     />
@@ -410,29 +455,23 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                   <TableCell>
                     <Input 
                       placeholder="e.g. City of Seattle"
-                      className="border-transparent hover:border-slate-200 bg-transparent h-8 shadow-none text-sm text-slate-500" 
+                      className="border-border/40 hover:border-border bg-transparent h-8 shadow-none text-sm text-muted-foreground" 
                       defaultValue={item.vendor || ''}
                       onBlur={e => { if(e.target.value !== item.vendor) handleUpdate(item.id, { vendor: e.target.value }) }}
                     />
                   </TableCell>
                   <TableCell className="text-right">
-                    <Input 
-                      type="number" 
-                      className="w-24 h-8 text-right ml-auto" 
-                      defaultValue={item.cost.toString()} 
-                      onBlur={(e) => {
-                        if(Number(e.target.value) !== item.cost) handleUpdate(item.id, { cost: Number(e.target.value) })
-                      }}
+                    <MoneyInput
+                      value={item.cost}
+                      onCommit={(n) => handleUpdate(item.id, { cost: n })}
+                      className="w-24 h-8 text-right ml-auto"
                     />
                   </TableCell>
                   <TableCell className="text-right">
-                    <Input 
-                      type="number" 
-                      className="w-24 h-8 text-right font-bold text-slate-800 ml-auto" 
-                      defaultValue={item.client_price.toString()} 
-                      onBlur={(e) => {
-                        if(Number(e.target.value) !== item.client_price) handleUpdate(item.id, { client_price: Number(e.target.value) })
-                      }}
+                    <MoneyInput
+                      value={item.client_price}
+                      onCommit={(n) => handleUpdate(item.id, { client_price: n })}
+                      className="w-24 h-8 text-right font-bold text-foreground ml-auto"
                     />
                   </TableCell>
                   <TableCell>
@@ -444,13 +483,13 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                         <Button
                           variant="ghost"
                           size="icon"
-                          className="h-8 w-8 text-slate-400 hover:text-red-500 opacity-0 group-hover:opacity-100"
+                          className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100"
                         >
                           <Trash2 className="w-4 h-4" />
                         </Button>
                       </PopoverTrigger>
                       <PopoverContent side="top" align="end" className="w-52 p-3">
-                        <p className="mb-2 text-xs text-slate-700">Delete this service?</p>
+                        <p className="mb-2 text-xs text-foreground">Delete this service?</p>
                         <div className="flex justify-end gap-2">
                           <Button
                             variant="outline"
@@ -462,7 +501,7 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                           </Button>
                           <Button
                             size="sm"
-                            className="h-7 px-2 text-xs bg-red-600 hover:bg-red-700 text-white"
+                            className="h-7 px-2 text-xs bg-destructive hover:bg-destructive/90 text-white"
                             disabled={deletingItemId === item.id}
                             onClick={() => handleDelete(item.id)}
                           >
@@ -476,7 +515,7 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
               ))}
               {siteServices.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={6} className="text-center text-slate-400 py-6 italic">No site services added.</TableCell>
+                  <TableCell colSpan={6} className="text-center text-muted-foreground py-6 italic">No site services added.</TableCell>
                 </TableRow>
               )}
             </TableBody>
@@ -484,16 +523,16 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
         </div>
       </div>
 
-      <div className="bg-slate-900 text-white p-4 flex justify-between items-center rounded-b-lg mt-0 mx-0 shadow-inner">
-        <h3 className="font-bold tracking-widest text-sm text-orange-400 font-mono">TOTAL MATERIALS & PERMITS</h3>
+      <div className="rounded-xl border bg-muted/40 p-4 flex justify-between items-center mt-2">
+        <h3 className="font-bold tracking-wider text-xs uppercase text-muted-foreground">Total Materials &amp; Permits</h3>
         <div className="flex gap-8 text-sm">
           <div className="text-right">
-            <span className="text-slate-400 mr-2 text-xs uppercase">Total Cost</span>
-            <span className="font-semibold tracking-wide text-slate-200">{formatCurrency(totalCost)}</span>
+            <span className="text-muted-foreground mr-2 text-xs uppercase">Total Cost</span>
+            <span className="font-semibold tracking-wide text-foreground">{formatCurrency(totalCost)}</span>
           </div>
-          <div className="text-right border-l border-slate-700 pl-6">
-            <span className="text-slate-400 mr-2 text-xs uppercase">Total Client Price</span>
-            <span className="font-bold text-lg text-emerald-400">{formatCurrency(totalClientPrice)}</span>
+          <div className="text-right border-l border-border pl-6">
+            <span className="text-muted-foreground mr-2 text-xs uppercase">Total Client Price</span>
+            <span className="font-bold text-lg text-status-active">{formatCurrency(totalClientPrice)}</span>
           </div>
         </div>
       </div>
@@ -517,7 +556,7 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
               />
             </div>
             <div className="flex justify-end pt-4">
-              <Button type="submit" disabled={isSubmitting} className="bg-orange-500 hover:bg-orange-600">
+              <Button type="submit" disabled={isSubmitting} className="bg-primary hover:bg-primary/90">
                 {isSubmitting ? 'Saving...' : 'Save'}
               </Button>
             </div>
@@ -534,9 +573,9 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
       />
 
       <Dialog open={!!previewAttachment} onOpenChange={(open) => !open && setPreviewAttachment(null)}>
-        <DialogContent className="max-w-[90vw] w-full h-[90vh] p-0 flex flex-col gap-0 overflow-hidden bg-slate-100">
+        <DialogContent className="max-w-[90vw] w-full h-[90vh] p-0 flex flex-col gap-0 overflow-hidden bg-muted">
           <DialogHeader className="pt-4 pb-3 px-4 bg-white flex flex-row items-center justify-between shrink-0 shadow-sm z-10">
-            <DialogTitle className="text-base truncate pr-8 font-medium text-slate-800">{previewAttachment?.name || 'Preview'}</DialogTitle>
+            <DialogTitle className="text-base truncate pr-8 font-medium text-foreground">{previewAttachment?.name || 'Preview'}</DialogTitle>
           </DialogHeader>
           <div className="flex-1 overflow-hidden relative w-full h-[calc(90vh-65px)] flex items-center justify-center">
             {previewAttachment && (
@@ -546,12 +585,12 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
                 <iframe src={`${previewAttachment.url}#view=FitH`} className="w-full h-full border-0 bg-white" title={previewAttachment.name} />
               ) : (
                 <div className="text-center p-8 flex flex-col items-center bg-white rounded-xl shadow-sm border max-w-md mx-auto">
-                  <div className="bg-slate-50 p-4 rounded-full mb-4">
-                    <Link2 className="w-8 h-8 text-slate-400" />
+                  <div className="bg-muted p-4 rounded-full mb-4">
+                    <Link2 className="w-8 h-8 text-muted-foreground" />
                   </div>
-                  <h3 className="text-lg font-medium text-slate-800 mb-2">No Preview Available</h3>
-                  <p className="text-slate-500 mb-6 text-sm">This file type cannot be previewed in the browser.</p>
-                  <Button onClick={() => window.open(previewAttachment.url, '_blank')} className="bg-orange-500 hover:bg-orange-600">
+                  <h3 className="text-lg font-medium text-foreground mb-2">No Preview Available</h3>
+                  <p className="text-muted-foreground mb-6 text-sm">This file type cannot be previewed in the browser.</p>
+                  <Button onClick={() => window.open(previewAttachment.url, '_blank')} className="bg-primary hover:bg-primary/90">
                     Download File
                   </Button>
                 </div>
@@ -560,6 +599,17 @@ export function MaterialsPermitsTab({ project, onRefreshTotal, onProjectMediaCha
           </div>
         </DialogContent>
       </Dialog>
+
+      {quotePickerCategory && (
+        <QuoteItemPicker
+          projectId={project.id}
+          open={!!quotePickerCategory}
+          onOpenChange={(o) => { if (!o) setQuotePickerCategory(null) }}
+          pulledItemIds={pulledItemIds}
+          destinationLabel={quotePickerCategory === 'JOB_MATERIAL' ? 'Job Materials' : 'Site Services'}
+          onConfirm={(lineItems) => handleAddFromQuote(quotePickerCategory, lineItems)}
+        />
+      )}
     </div>
   )
 }

--- a/components/projects/financials/money-input.tsx
+++ b/components/projects/financials/money-input.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Input } from '@/components/ui/input'
+
+/** Strip anything that isn't a number, dot, or leading minus, then parse.
+ * Returns 0 for empty/garbage so a blanked cell becomes 0 rather than NaN. */
+export const parseMoney = (raw: string): number => {
+  const cleaned = raw.replace(/[^0-9.-]/g, '')
+  const n = parseFloat(cleaned)
+  return Number.isFinite(n) ? n : 0
+}
+
+/** A plain text money input — no `type="number"`, so there are no spinner
+ * (increment/decrement) buttons. `inputMode="decimal"` still gives a numeric
+ * keypad on mobile. Uncontrolled: commits the parsed number on blur / Enter,
+ * only when it actually changed. */
+export function MoneyInput({
+  value,
+  onCommit,
+  className,
+  placeholder,
+}: {
+  value: number
+  onCommit: (n: number) => void
+  className?: string
+  placeholder?: string
+}) {
+  return (
+    <Input
+      type="text"
+      inputMode="decimal"
+      placeholder={placeholder}
+      defaultValue={String(value ?? 0)}
+      onFocus={(e) => e.currentTarget.select()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') e.currentTarget.blur()
+      }}
+      onBlur={(e) => {
+        const parsed = parseMoney(e.currentTarget.value)
+        e.currentTarget.value = String(parsed)
+        if (parsed !== value) onCommit(parsed)
+      }}
+      className={className}
+    />
+  )
+}

--- a/components/projects/financials/project-financials.tsx
+++ b/components/projects/financials/project-financials.tsx
@@ -12,6 +12,7 @@ import { FinancialSidebar } from './financial-sidebar'
 import { JobCostingTab } from './job-costing-tab'
 import { MaterialsPermitsTab } from './materials-permits-tab'
 import { SummaryInvoicingTab } from './summary-invoicing-tab'
+import { ScopeBillingTab } from './scope-billing-tab'
 
 interface ProjectFinancialsProps {
   project: Project
@@ -54,30 +55,36 @@ export function ProjectFinancials({ project, onProjectUpdated }: ProjectFinancia
   if (loading && !summary) {
     return (
       <div className="flex justify-center items-center h-64">
-        <Loader2 className="w-8 h-8 animate-spin text-orange-500" />
+        <Loader2 className="w-8 h-8 animate-spin text-primary" />
       </div>
     )
   }
 
   return (
     <div className="animate-in fade-in duration-500">
-      <Tabs defaultValue="job-costing" className="w-full space-y-6">
-        <TabsList className="w-full flex overflow-x-auto flex-nowrap rounded-xl border border-slate-200 bg-slate-100 p-1.5 shadow-sm">
-          <TabsTrigger 
-            value="job-costing" 
-            className="h-11 min-w-[220px] flex-1 cursor-pointer whitespace-nowrap rounded-lg border border-transparent px-4 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:bg-white hover:text-slate-900 data-[state=active]:border-orange-500 data-[state=active]:bg-orange-500 data-[state=active]:text-white data-[state=active]:shadow-md"
+      <Tabs defaultValue="scope-billing" className="w-full space-y-6">
+        <TabsList className="w-full flex overflow-x-auto flex-nowrap rounded-xl border border-border bg-muted p-1.5 shadow-sm">
+          <TabsTrigger
+            value="scope-billing"
+            className="h-10 min-w-[140px] flex-1 cursor-pointer whitespace-nowrap rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-background hover:text-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm"
+          >
+            Scope &amp; Billing
+          </TabsTrigger>
+          <TabsTrigger
+            value="job-costing"
+            className="h-10 min-w-[140px] flex-1 cursor-pointer whitespace-nowrap rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-background hover:text-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm"
           >
             Job Costing (Labour & Subs)
           </TabsTrigger>
           <TabsTrigger 
             value="materials"
-            className="h-11 min-w-[220px] flex-1 cursor-pointer whitespace-nowrap rounded-lg border border-transparent px-4 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:bg-white hover:text-slate-900 data-[state=active]:border-orange-500 data-[state=active]:bg-orange-500 data-[state=active]:text-white data-[state=active]:shadow-md"
+            className="h-10 min-w-[140px] flex-1 cursor-pointer whitespace-nowrap rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-background hover:text-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm"
           >
             Materials & Permits
           </TabsTrigger>
           <TabsTrigger 
             value="summary"
-            className="h-11 min-w-[220px] flex-1 cursor-pointer whitespace-nowrap rounded-lg border border-transparent px-4 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:bg-white hover:text-slate-900 data-[state=active]:border-orange-500 data-[state=active]:bg-orange-500 data-[state=active]:text-white data-[state=active]:shadow-md"
+            className="h-10 min-w-[140px] flex-1 cursor-pointer whitespace-nowrap rounded-lg px-4 text-sm font-semibold text-muted-foreground transition-colors hover:bg-background hover:text-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm"
           >
             Summary & Invoicing
           </TabsTrigger>
@@ -85,7 +92,12 @@ export function ProjectFinancials({ project, onProjectUpdated }: ProjectFinancia
 
         <div className="flex flex-col lg:flex-row gap-6">
           {/* Main Content Area (Tabs) */}
-          <div className="flex-1 min-w-0">            <div className="bg-white rounded-lg border shadow-sm">
+          <div className="flex-1 min-w-0">
+            <div className="bg-card rounded-lg border shadow-sm">
+              <TabsContent value="scope-billing" className="p-0 m-0 border-none outline-none">
+                <ScopeBillingTab project={project} />
+              </TabsContent>
+
               <TabsContent value="job-costing" className="p-0 m-0 border-none outline-none">
                 <JobCostingTab project={project} onRefreshTotal={refreshFinancialData} />
               </TabsContent>

--- a/components/projects/financials/quote-item-picker.tsx
+++ b/components/projects/financials/quote-item-picker.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+// Reusable "Add from quote" picker. Lists the line items of every quote linked to
+// the project (anchor + change orders) so you can pull scope into Job Costing or
+// Materials instead of re-typing it. Items already pulled in are greyed out, and
+// quotes that aren't part of the contract (draft/rejected/superseded) are disabled
+// so you can't seed cost lines from scope the contract total itself excludes.
+
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { api } from '@/lib/api'
+import { ProjectScopeBilling, ScopeQuoteLineItem } from '@/lib/types'
+import { formatCurrency } from '@/lib/utils'
+import { Loader2, Check } from 'lucide-react'
+
+interface QuoteItemPickerProps {
+  projectId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** source_job_item_ids already pulled into this destination — shown as "Added". */
+  pulledItemIds: Set<number>
+  /** e.g. "FRAMING phase" or "Job Materials" — shown in the title. */
+  destinationLabel: string
+  onConfirm: (items: ScopeQuoteLineItem[]) => Promise<void> | void
+}
+
+export function QuoteItemPicker({
+  projectId,
+  open,
+  onOpenChange,
+  pulledItemIds,
+  destinationLabel,
+  onConfirm,
+}: QuoteItemPickerProps) {
+  const [scope, setScope] = useState<ProjectScopeBilling | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [selected, setSelected] = useState<Set<number>>(new Set())
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setSelected(new Set())
+    let active = true
+    ;(async () => {
+      try {
+        setLoading(true)
+        const res = await api.getProjectScopeBilling(projectId)
+        if (active) setScope(res)
+      } finally {
+        if (active) setLoading(false)
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [open, projectId])
+
+  const toggle = (id: number) =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+
+  // Only contract quotes (anchor or approved) are pullable; a superseded/rejected
+  // quote is shown but disabled, never selectable.
+  const allItems: ScopeQuoteLineItem[] = (scope?.quotes || [])
+    .filter((q) => q.counts_toward_contract)
+    .flatMap((q) => q.line_items)
+  const chosen = allItems.filter((li) => selected.has(li.id))
+
+  const confirm = async () => {
+    if (!chosen.length) return
+    setSubmitting(true)
+    try {
+      await onConfirm(chosen)
+      onOpenChange(false)
+    } catch {
+      // onConfirm already surfaced the error (toast). Keep the dialog open so the
+      // user can retry/cancel — and so any rows that DID save aren't hidden behind a
+      // close (they're committed to the destination list and deduped on re-open).
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[640px] max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="text-base">Add from quote → {destinationLabel}</DialogTitle>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="py-12 text-center">
+            <Loader2 className="w-6 h-6 animate-spin mx-auto text-primary" />
+          </div>
+        ) : !scope || scope.quotes.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">No quotes linked to this project.</p>
+        ) : (
+          <div className="flex-1 overflow-y-auto -mx-1 px-1 space-y-4">
+            {scope.quotes.map((q) => (
+              <div key={q.job_id}>
+                <div className="flex items-center gap-2 mb-1.5">
+                  <span className="text-sm font-semibold text-foreground">{q.title}</span>
+                  {q.is_anchor && (
+                    <Badge variant="outline" className="border-primary/30 bg-primary/10 text-primary text-[10px]">
+                      Primary
+                    </Badge>
+                  )}
+                  {q.is_change_order && (
+                    <Badge variant="outline" className="border-chart-4/20 bg-chart-4/10 text-chart-4 text-[10px]">
+                      Change order
+                    </Badge>
+                  )}
+                  {!q.counts_toward_contract && (
+                    <Badge variant="outline" className="border-border text-[10px] text-muted-foreground">
+                      Not in contract · {q.status}
+                    </Badge>
+                  )}
+                </div>
+                <div className="space-y-1">
+                  {q.line_items.length === 0 && (
+                    <p className="text-xs text-muted-foreground px-1">No line items on this quote.</p>
+                  )}
+                  {q.line_items.map((li) => {
+                    const already = pulledItemIds.has(li.id)
+                    const isSel = selected.has(li.id)
+                    // Block items already pulled, or whose quote isn't part of the contract.
+                    const blocked = already || !q.counts_toward_contract
+                    return (
+                      <button
+                        key={li.id}
+                        type="button"
+                        disabled={blocked}
+                        onClick={() => toggle(li.id)}
+                        className={`w-full flex items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors ${
+                          blocked
+                            ? 'opacity-50 cursor-not-allowed border-border bg-muted'
+                            : isSel
+                            ? 'border-primary/30 bg-primary/10'
+                            : 'border-border hover:border-border'
+                        }`}
+                      >
+                        <span
+                          className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                            isSel ? 'bg-primary border-primary text-white' : 'border-border'
+                          }`}
+                        >
+                          {isSel && <Check className="h-3 w-3" />}
+                        </span>
+                        <span className="flex-1 min-w-0 truncate text-sm text-foreground">{li.description}</span>
+                        {already && <Badge variant="outline" className="text-[10px] text-muted-foreground">Added</Badge>}
+                        <span className="shrink-0 text-right text-xs tabular-nums">
+                          <span className="text-muted-foreground">cost {formatCurrency(li.cost)}</span>
+                          {' · '}
+                          <span className="font-medium text-foreground">{formatCurrency(li.total)}</span>
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-2 flex justify-end gap-2 border-t pt-3">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            className="bg-primary hover:bg-primary/90"
+            disabled={!chosen.length || submitting}
+            onClick={confirm}
+          >
+            {submitting ? 'Adding…' : `Add ${chosen.length || ''} item${chosen.length === 1 ? '' : 's'}`}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/projects/financials/scope-billing-tab.tsx
+++ b/components/projects/financials/scope-billing-tab.tsx
@@ -1,0 +1,493 @@
+'use client'
+
+// Scope & Billing — the reconciled view that ties a project's quotes (+ line
+// items) → draws → invoices together. Everything here derives from the accepted
+// quote(s); this tab is read-only and links out to the quote for billing
+// actions, so the numbers are a single source of truth rather than re-entered.
+
+import { useEffect, useState } from 'react'
+import { useLocale } from 'next-intl'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
+import { api } from '@/lib/api'
+import { Project, ProjectScopeBilling } from '@/lib/types'
+import { formatCurrency } from '@/lib/utils'
+import { useToast } from '@/components/ui/use-toast'
+import { Loader2, AlertTriangle, FileText, ArrowUpRight, CheckCircle2 } from 'lucide-react'
+
+interface ScopeBillingTabProps {
+  project: Project
+}
+
+const DRAW_STATE_STYLES: Record<string, string> = {
+  PAID: 'bg-status-active/15 text-status-active border-status-active/30',
+  INVOICED: 'bg-status-pending/15 text-status-pending border-status-pending/30',
+  READY: 'bg-primary/15 text-primary border-primary/20',
+  SCHEDULED: 'bg-muted text-muted-foreground border-border',
+}
+
+const INVOICE_STATUS_STYLES: Record<string, string> = {
+  PAID: 'bg-status-active/15 text-status-active border-status-active/30',
+  PARTIALLY_PAID: 'bg-status-pending/15 text-status-pending border-status-pending/30',
+  SENT: 'bg-primary/15 text-primary border-primary/20',
+  PENDING: 'bg-primary/15 text-primary border-primary/20',
+  OVERDUE: 'bg-destructive/15 text-destructive border-destructive/30',
+  DRAFT: 'bg-muted text-muted-foreground border-border',
+}
+
+const pct = (n: number) => `${Math.round(n)}%`
+
+/** A two-segment progress bar: collected/paid (green) then invoiced-but-not-yet-
+ * collected (amber), over a muted "remaining" track. */
+function BillingBar({ paid, billed, total, className }: { paid: number; billed: number; total: number; className?: string }) {
+  const denom = total > 0 ? total : 1
+  const paidPct = Math.max(0, Math.min(100, (paid / denom) * 100))
+  const billedExtraPct = Math.max(0, Math.min(100 - paidPct, ((billed - paid) / denom) * 100))
+  return (
+    <div className={`flex w-full overflow-hidden rounded-full bg-muted ${className ?? 'h-2'}`}>
+      <div className="bg-status-active transition-all duration-500" style={{ width: `${paidPct}%` }} />
+      <div className="bg-status-pending transition-all duration-500" style={{ width: `${billedExtraPct}%` }} />
+    </div>
+  )
+}
+
+export function ScopeBillingTab({ project }: ScopeBillingTabProps) {
+  const { toast } = useToast()
+  const locale = useLocale()
+  // Open quotes / invoices in a new browser tab so the financials page stays put.
+  const openTab = (path: string) => window.open(`/${locale}${path}`, '_blank', 'noopener,noreferrer')
+
+  const [loading, setLoading] = useState(true)
+  const [data, setData] = useState<ProjectScopeBilling | null>(null)
+
+  useEffect(() => {
+    let active = true
+    ;(async () => {
+      try {
+        setLoading(true)
+        const res = await api.getProjectScopeBilling(project.id)
+        if (active) setData(res)
+      } catch (err: any) {
+        toast({ title: 'Error loading scope & billing', description: err.message, variant: 'destructive' })
+      } finally {
+        if (active) setLoading(false)
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [project.id])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      </div>
+    )
+  }
+
+  if (!data) {
+    return <div className="p-8 text-center text-sm text-muted-foreground">No financial data available.</div>
+  }
+
+  const { contract, quotes, schedules, invoices, reconciliation } = data
+  const anchor = quotes.find((q) => q.is_anchor)
+  // Show EVERY linked quote (anchor first), not just anchor + change orders — a
+  // project can have multiple independent quotes linked, and they must all show.
+  const orderedQuotes = [...quotes].sort((a, b) => Number(b.is_anchor) - Number(a.is_anchor))
+  const baseQuoteCount = quotes.filter((q) => !q.is_change_order).length
+  const hasDrift = contract.source === 'override' && Math.abs(contract.drift) > 0.01
+  const fullyReconciled =
+    Math.abs(reconciliation.uninvoiced_remaining) < 0.01 &&
+    Math.abs(reconciliation.contract_total - reconciliation.collected_total) < 0.01
+
+  // Headline figures + progress.
+  const contractTotal = reconciliation.contract_total
+  const invoicedTotal = reconciliation.invoiced_total
+  const collectedTotal = reconciliation.collected_total
+  const overInvoiced = reconciliation.uninvoiced_remaining < -0.01
+  const denom = contractTotal > 0 ? contractTotal : 1
+  const invoicedPct = Math.max(0, Math.min(100, (invoicedTotal / denom) * 100))
+  const collectedPct = Math.max(0, Math.min(100, (collectedTotal / denom) * 100))
+
+  // Section subtotals (placed in each section's header).
+  const scopeTotal = quotes.reduce((s, q) => s + q.grand_total, 0)
+  const invTotal = invoices.reduce((s, i) => s + i.total_amount, 0)
+  const invPaid = invoices.reduce((s, i) => s + i.amount_paid, 0)
+  const invBalance = invoices.reduce((s, i) => s + i.balance_due, 0)
+
+  // Keep the lists clean: every quote/plan starts collapsed; the user expands
+  // the ones they care about.
+  const defaultOpenScope: string[] = []
+  const defaultOpenPlan: string[] = []
+
+  const stats: { label: string; value: string; accent: string }[] = [
+    { label: 'Contract', value: formatCurrency(contractTotal), accent: 'text-foreground' },
+    { label: 'Planned', value: formatCurrency(reconciliation.scheduled_total), accent: 'text-foreground' },
+    { label: 'Invoiced', value: formatCurrency(invoicedTotal), accent: 'text-status-pending' },
+    { label: 'Collected', value: formatCurrency(collectedTotal), accent: 'text-status-active' },
+    overInvoiced
+      ? { label: 'Over-invoiced', value: formatCurrency(Math.abs(reconciliation.uninvoiced_remaining)), accent: 'text-destructive' }
+      : { label: 'Uninvoiced', value: formatCurrency(reconciliation.uninvoiced_remaining), accent: 'text-primary' },
+  ]
+
+  return (
+    <div className="p-4 space-y-6">
+      {/* ── Billing summary (headline) ── */}
+      <Card className="border shadow-sm">
+        <CardContent className="p-5 space-y-5">
+          {/* Contract total + where it comes from, with a status pill */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Contract total</p>
+              <p className="text-3xl font-bold tabular-nums text-foreground leading-tight">{formatCurrency(contractTotal)}</p>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {contract.source === 'quote' && (
+                  <span className="inline-flex flex-wrap items-center gap-1">
+                    Derived from {baseQuoteCount > 1 ? `${baseQuoteCount} quotes` : (anchor ? anchor.title : 'the accepted quote')}
+                    {' '}({formatCurrency(contract.base_contract)})
+                    {contract.approved_co_total > 0 && (
+                      <> + {formatCurrency(contract.approved_co_total)} change orders</>
+                    )}
+                  </span>
+                )}
+                {contract.source === 'override' && (
+                  <span>Manually set · quote-derived is {formatCurrency(contract.derived_total)}</span>
+                )}
+                {contract.source === 'none' && <span>No accepted quote linked yet.</span>}
+              </div>
+            </div>
+            <div className="shrink-0">
+              {hasDrift ? (
+                <Badge variant="outline" className="border-status-pending/30 bg-status-pending/10 text-status-pending">Overridden</Badge>
+              ) : fullyReconciled ? (
+                <Badge variant="outline" className="border-status-active/30 bg-status-active/10 text-status-active">
+                  <CheckCircle2 className="mr-1 h-3.5 w-3.5" /> Reconciled
+                </Badge>
+              ) : contract.source === 'quote' ? (
+                <Badge variant="outline" className="border-status-active/30 bg-status-active/10 text-status-active">From scope</Badge>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Progress: collected (green) + invoiced-not-collected (amber) of contract */}
+          <div className="space-y-1.5">
+            <BillingBar paid={collectedTotal} billed={invoicedTotal} total={contractTotal} className="h-2.5" />
+            <div className="flex flex-wrap justify-between gap-x-4 text-[11px] font-medium text-muted-foreground">
+              <span className="inline-flex items-center gap-3">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 rounded-full bg-status-active" /> {pct(collectedPct)} collected
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 rounded-full bg-status-pending" /> {pct(invoicedPct)} invoiced
+                </span>
+              </span>
+              {!overInvoiced && (
+                <span className="tabular-nums">{formatCurrency(reconciliation.uninvoiced_remaining)} left to invoice</span>
+              )}
+            </div>
+          </div>
+
+          {/* The five figures, as a clean responsive grid of chips */}
+          <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-5">
+            {stats.map((s) => (
+              <div key={s.label} className="rounded-lg border bg-card px-3 py-2.5">
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">{s.label}</p>
+                <p className={`text-lg font-bold tabular-nums leading-tight ${s.accent}`}>{s.value}</p>
+              </div>
+            ))}
+          </div>
+
+          {hasDrift && (
+            <div className="flex items-start gap-2 rounded-md bg-status-pending/10 border border-status-pending/30 px-3 py-2 text-xs text-status-pending">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              <span>
+                The contract value is overridden and differs from the quote by{' '}
+                <strong>{formatCurrency(Math.abs(contract.drift))}</strong>{' '}
+                ({contract.drift > 0 ? 'over' : 'under'} the quoted scope). Update the quote or clear the
+                override to reconcile.
+              </span>
+            </div>
+          )}
+          {overInvoiced && (
+            <div className="flex items-start gap-2 rounded-md bg-destructive/10 border border-destructive/30 px-3 py-2 text-xs text-destructive">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              <span>
+                Invoiced <strong>{formatCurrency(Math.abs(reconciliation.uninvoiced_remaining))}</strong> more than the
+                contract total. Check the Invoices list for stray or duplicate invoices.
+              </span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Scope: quotes + line items (collapsible) ── */}
+      <Card className="border shadow-sm">
+        <CardHeader className="pb-3 flex flex-row items-center justify-between gap-3">
+          <CardTitle className="text-sm font-bold uppercase tracking-wider text-foreground">
+            Scope {quotes.length > 0 && <span className="text-muted-foreground font-medium normal-case">· {quotes.length} quote{quotes.length === 1 ? '' : 's'}</span>}
+          </CardTitle>
+          {quotes.length > 0 && (
+            <span className="text-sm font-bold tabular-nums text-foreground">{formatCurrency(scopeTotal)}</span>
+          )}
+        </CardHeader>
+        <CardContent>
+          {quotes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No quotes linked to this project.</p>
+          ) : (
+            <Accordion type="multiple" defaultValue={defaultOpenScope} className="space-y-3">
+              {orderedQuotes.map((q) => (
+                <AccordionItem key={q.job_id} value={`q-${q.job_id}`} className="rounded-lg border border-border overflow-hidden">
+                  <AccordionTrigger className="px-4 py-2.5 bg-muted hover:no-underline [&[data-state=open]]:border-b">
+                    <div className="flex flex-1 items-center justify-between gap-2 min-w-0 pr-2">
+                      <span className="flex items-center gap-2 min-w-0 flex-wrap">
+                        <span className="truncate text-sm font-semibold text-foreground">{q.title}</span>
+                        {q.is_anchor && <Badge variant="outline" className="border-primary/30 bg-primary/10 text-primary">Primary contract</Badge>}
+                        {q.is_change_order && <Badge variant="outline" className="border-chart-4/20 bg-chart-4/10 text-chart-4">Change order</Badge>}
+                        <Badge variant="outline" className="text-muted-foreground">{q.status}</Badge>
+                        <span className="text-xs text-muted-foreground">{q.line_items.length} item{q.line_items.length === 1 ? '' : 's'}</span>
+                      </span>
+                      <span className="text-sm font-bold tabular-nums text-foreground shrink-0">{formatCurrency(q.grand_total)}</span>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="pb-0">
+                    <div className="flex justify-end border-b bg-muted/30 px-4 py-1.5">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 text-muted-foreground hover:text-primary"
+                        onClick={() => openTab(`/quotes/${q.job_id}`)}
+                      >
+                        Open quote <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                    {q.line_items.length > 0 ? (
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="text-[10px] uppercase tracking-wider text-muted-foreground border-b">
+                            <th className="px-4 py-1.5 text-left font-semibold">Item</th>
+                            <th className="px-4 py-1.5 text-right font-semibold whitespace-nowrap">Qty × Rate</th>
+                            <th className="px-4 py-1.5 text-right font-semibold">Amount</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-border">
+                          {q.line_items.map((li) => (
+                            <tr key={li.id}>
+                              <td className="px-4 py-2 text-foreground">{li.description}</td>
+                              <td className="px-4 py-2 text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                                {li.quantity} {li.unit_of_measure || ''} × {formatCurrency(li.unit_price)}
+                              </td>
+                              <td className="px-4 py-2 text-right tabular-nums font-medium text-foreground whitespace-nowrap">
+                                {formatCurrency(li.total)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    ) : (
+                      <p className="px-4 py-3 text-xs text-muted-foreground">No line items on this quote.</p>
+                    )}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Payment plan (collapsible; one per quote: draws, or a single payment) ── */}
+      <Card className="border shadow-sm">
+        <CardHeader className="pb-3 flex flex-row items-center justify-between gap-3">
+          <CardTitle className="text-sm font-bold uppercase tracking-wider text-foreground">
+            Payment Plan
+            {schedules.length > 1 && (
+              <span className="text-muted-foreground font-medium normal-case"> · {schedules.length} quotes</span>
+            )}
+          </CardTitle>
+          {schedules.length > 0 && (
+            <span className="text-xs text-muted-foreground tabular-nums">
+              Planned <span className="font-semibold text-foreground">{formatCurrency(reconciliation.scheduled_total)}</span> of {formatCurrency(reconciliation.contract_total)}
+            </span>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {schedules.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No billing plan yet — link an accepted quote to bill against it.
+            </p>
+          ) : (
+            <Accordion type="multiple" defaultValue={defaultOpenPlan} className="space-y-3">
+              {schedules.map((sch) => {
+                // A quote with no draws bills as one payment — show the amount payable
+                // through it rather than hiding the quote entirely.
+                const lumpSum = !sch.has_draws || sch.lines.length === 0
+                return (
+                  <AccordionItem key={sch.job_id} value={`s-${sch.job_id}`} className="rounded-lg border border-border overflow-hidden">
+                    <AccordionTrigger className="px-4 py-2.5 bg-muted hover:no-underline [&[data-state=open]]:border-b">
+                      <div className="flex flex-1 items-center justify-between gap-2 min-w-0 pr-2">
+                        <span className="flex items-center gap-2 min-w-0 flex-wrap">
+                          <span className="truncate text-sm font-semibold text-foreground">{sch.quote_title}</span>
+                          {sch.is_anchor && <Badge variant="outline" className="border-primary/30 bg-primary/10 text-primary">Primary contract</Badge>}
+                          {sch.is_change_order && <Badge variant="outline" className="border-chart-4/20 bg-chart-4/10 text-chart-4">Change order</Badge>}
+                          {lumpSum && <Badge variant="outline" className="text-muted-foreground">Single payment</Badge>}
+                        </span>
+                        <span className="text-sm font-bold tabular-nums text-foreground shrink-0">{formatCurrency(sch.contract_total)}</span>
+                      </div>
+                    </AccordionTrigger>
+                    <AccordionContent className="pb-0">
+                      <div className="p-3 space-y-1.5">
+                        <div className="flex justify-end">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7"
+                            onClick={() => openTab(`/quotes/${sch.job_id}`)}
+                          >
+                            {lumpSum ? 'Bill' : 'Bill draws'} <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                        {lumpSum ? (
+                          <div className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-border px-3 py-2">
+                            <span className="text-sm font-medium text-foreground">
+                              Payable in full <span className="text-muted-foreground">· no draw schedule</span>
+                            </span>
+                            <span className="text-sm font-semibold tabular-nums text-foreground shrink-0">
+                              {formatCurrency(sch.contract_total)}
+                            </span>
+                          </div>
+                        ) : (
+                          sch.lines.map((line) => (
+                            <div key={line.id} className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2">
+                              <div className="flex items-center gap-2 min-w-0">
+                                <span className="truncate text-sm font-medium text-foreground">{line.label}</span>
+                                <Badge variant="outline" className={DRAW_STATE_STYLES[line.state] || 'text-muted-foreground'}>{line.state}</Badge>
+                                {line.invoice_id && line.invoice_number ? (
+                                  <button
+                                    type="button"
+                                    onClick={() => openTab(`/invoices/${line.invoice_id}`)}
+                                    className="text-xs text-primary hover:underline"
+                                  >
+                                    {line.invoice_number}
+                                  </button>
+                                ) : (
+                                  line.invoice_number && <span className="text-xs text-muted-foreground">{line.invoice_number}</span>
+                                )}
+                              </div>
+                              <span className="text-sm font-semibold tabular-nums text-foreground shrink-0">
+                                {formatCurrency(line.computed_amount)}
+                              </span>
+                            </div>
+                          ))
+                        )}
+                        {/* Per-quote billed/paid progress */}
+                        <div className="pt-1.5">
+                          <BillingBar paid={sch.summary.paid} billed={sch.summary.billed} total={sch.contract_total} className="h-1.5" />
+                        </div>
+                        <div className="flex justify-between text-xs text-muted-foreground">
+                          <span className="tabular-nums">
+                            {lumpSum
+                              ? `Payable ${formatCurrency(sch.contract_total)}`
+                              : `Scheduled ${formatCurrency(sch.scheduled_total)} of ${formatCurrency(sch.contract_total)}`}
+                          </span>
+                          <span className="tabular-nums">
+                            Billed {formatCurrency(sch.summary.billed)} · <span className="text-status-active">Paid {formatCurrency(sch.summary.paid)}</span>
+                          </span>
+                        </div>
+                      </div>
+                    </AccordionContent>
+                  </AccordionItem>
+                )
+              })}
+            </Accordion>
+          )}
+          {schedules.length > 1 && (
+            <div className="flex justify-between pt-1 text-xs font-semibold text-foreground border-t">
+              <span>Planned across {schedules.length} quotes</span>
+              <span className="tabular-nums">
+                {formatCurrency(reconciliation.scheduled_total)} of {formatCurrency(reconciliation.contract_total)}
+              </span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Invoices ── */}
+      <Card className="border shadow-sm">
+        <CardHeader className="pb-3 flex flex-row items-center justify-between gap-3">
+          <CardTitle className="text-sm font-bold uppercase tracking-wider text-foreground">
+            Invoices {invoices.length > 0 && <span className="text-muted-foreground font-medium normal-case">· {invoices.length}</span>}
+          </CardTitle>
+          {invoices.length > 0 && (
+            <span className="text-xs text-muted-foreground tabular-nums">
+              <span className="text-status-active font-semibold">{formatCurrency(invPaid)}</span> collected of {formatCurrency(invTotal)}
+            </span>
+          )}
+        </CardHeader>
+        <CardContent>
+          {invoices.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No invoices raised yet.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-[11px] uppercase tracking-wider text-muted-foreground border-b">
+                    <th className="px-3 py-1.5 text-left font-semibold">Invoice</th>
+                    <th className="px-3 py-1.5 text-left font-semibold">Status</th>
+                    <th className="px-3 py-1.5 text-right font-semibold">Total</th>
+                    <th className="px-3 py-1.5 text-right font-semibold">Paid</th>
+                    <th className="px-3 py-1.5 text-right font-semibold">Balance</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {invoices.map((inv) => (
+                    <tr
+                      key={inv.id}
+                      role="link"
+                      tabIndex={0}
+                      onClick={() => openTab(`/invoices/${inv.id}`)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          openTab(`/invoices/${inv.id}`)
+                        }
+                      }}
+                      className="cursor-pointer hover:bg-muted focus:bg-muted focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+                    >
+                      <td className="px-3 py-2">
+                        <div className="flex items-center gap-2">
+                          <FileText className="h-3.5 w-3.5 text-muted-foreground" />
+                          <span className="font-medium text-primary hover:underline">{inv.invoice_number}</span>
+                          {inv.is_draw && <Badge variant="outline" className="text-muted-foreground text-[10px]">draw</Badge>}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2">
+                        <Badge variant="outline" className={INVOICE_STATUS_STYLES[inv.status || 'DRAFT'] || 'text-muted-foreground'}>
+                          {inv.status}
+                        </Badge>
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums text-foreground">{formatCurrency(inv.total_amount)}</td>
+                      <td className="px-3 py-2 text-right tabular-nums text-status-active">{formatCurrency(inv.amount_paid)}</td>
+                      <td className="px-3 py-2 text-right tabular-nums text-primary">{formatCurrency(inv.balance_due)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr className="border-t font-semibold">
+                    <td colSpan={2} className="px-3 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+                      Total · {invoices.length} invoice{invoices.length === 1 ? '' : 's'}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-foreground">{formatCurrency(invTotal)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-status-active">{formatCurrency(invPaid)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-primary">{formatCurrency(invBalance)}</td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/projects/financials/summary-invoicing-tab.tsx
+++ b/components/projects/financials/summary-invoicing-tab.tsx
@@ -40,19 +40,19 @@ function getStatusBadge(status: string) {
   switch (status) {
     case 'Paid':
       return (
-        <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 font-semibold">
+        <Badge className="bg-status-active/15 text-status-active border-status-active/30 font-semibold">
           <CheckCircle2 className="w-3 h-3 mr-1" /> Paid
         </Badge>
       )
     case 'Partially Paid':
       return (
-        <Badge className="bg-amber-100 text-amber-700 border-amber-200 font-semibold">
+        <Badge className="bg-status-pending/15 text-status-pending border-status-pending/30 font-semibold">
           <Clock className="w-3 h-3 mr-1" /> Partially Paid
         </Badge>
       )
     default:
       return (
-        <Badge className="bg-blue-100 text-blue-700 border-blue-200 font-semibold">
+        <Badge className="bg-primary/15 text-primary border-primary/20 font-semibold">
           <AlertCircle className="w-3 h-3 mr-1" /> Open
         </Badge>
       )
@@ -70,21 +70,21 @@ function QboInvoiceCard({ detail }: { detail: InvoiceRow }) {
           : ''
 
   return (
-    <Card className="border-slate-200 overflow-hidden">
-      <div className="bg-gradient-to-r from-slate-50 to-white p-4 border-b flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+    <Card className="border-border overflow-hidden">
+      <div className="bg-gradient-to-r from-muted to-card p-4 border-b flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div className="min-w-0 space-y-1">
           <div className="flex items-center gap-2 flex-wrap">
-            <h3 className="text-base font-bold text-slate-800">
+            <h3 className="text-base font-bold text-foreground">
               Inv. {detail.doc_number || detail.qbo_invoice_id}
             </h3>
-            <span className="text-xs text-slate-500">#{detail.job_id}</span>
+            <span className="text-xs text-muted-foreground">#{detail.job_id}</span>
             {getStatusBadge(detail.status)}
           </div>
-          {dateStr && <p className="text-xs text-slate-500">{dateStr}</p>}
+          {dateStr && <p className="text-xs text-muted-foreground">{dateStr}</p>}
         </div>
         {detail.qbo_invoice_url && (
           <a href={detail.qbo_invoice_url} target="_blank" rel="noopener noreferrer" className="shrink-0">
-            <Button variant="outline" size="sm" className="border-blue-200 text-blue-600 hover:bg-blue-50 h-8">
+            <Button variant="outline" size="sm" className="border-primary/20 text-primary hover:bg-primary/10 h-8">
               <ExternalLink className="w-3.5 h-3.5 mr-1" /> QBO
             </Button>
           </a>
@@ -93,29 +93,29 @@ function QboInvoiceCard({ detail }: { detail: InvoiceRow }) {
 
       <div className="grid grid-cols-3 divide-x border-b text-center">
         <div className="p-3">
-          <p className="text-[10px] font-semibold text-slate-400 uppercase">Total</p>
-          <p className="text-lg font-bold text-slate-800 mt-0.5">{formatCurrency(detail.total)}</p>
+          <p className="text-[10px] font-semibold text-muted-foreground uppercase">Total</p>
+          <p className="text-lg font-bold text-foreground mt-0.5">{formatCurrency(detail.total)}</p>
         </div>
         <div className="p-3">
-          <p className="text-[10px] font-semibold text-emerald-600 uppercase">Paid</p>
-          <p className="text-lg font-bold text-emerald-600 mt-0.5">{formatCurrency(detail.amount_paid)}</p>
+          <p className="text-[10px] font-semibold text-status-active uppercase">Paid</p>
+          <p className="text-lg font-bold text-status-active mt-0.5">{formatCurrency(detail.amount_paid)}</p>
         </div>
         <div className="p-3">
-          <p className="text-[10px] font-semibold text-orange-600 uppercase">Due</p>
-          <p className="text-lg font-bold text-orange-600 mt-0.5">{formatCurrency(detail.balance)}</p>
+          <p className="text-[10px] font-semibold text-primary uppercase">Due</p>
+          <p className="text-lg font-bold text-primary mt-0.5">{formatCurrency(detail.balance)}</p>
         </div>
       </div>
 
       {detail.line_items.length > 0 && (
         <details className="group border-b">
-          <summary className="px-4 py-2.5 text-xs font-medium text-slate-600 cursor-pointer list-none flex items-center justify-between hover:bg-slate-50/80 [&::-webkit-details-marker]:hidden">
+          <summary className="px-4 py-2.5 text-xs font-medium text-muted-foreground cursor-pointer list-none flex items-center justify-between hover:bg-muted/80 [&::-webkit-details-marker]:hidden">
             <span>Line items ({detail.line_items.length})</span>
-            <span className="text-slate-400 group-open:rotate-180 transition-transform">▼</span>
+            <span className="text-muted-foreground group-open:rotate-180 transition-transform">▼</span>
           </summary>
           <div className="overflow-x-auto border-t">
             <table className="w-full text-sm">
               <thead>
-                <tr className="bg-slate-50 text-[10px] uppercase tracking-wider text-slate-500">
+                <tr className="bg-muted text-[10px] uppercase tracking-wider text-muted-foreground">
                   <th className="text-left p-2 font-semibold">Item</th>
                   <th className="text-right p-2 font-semibold">Qty</th>
                   <th className="text-right p-2 font-semibold">Rate</th>
@@ -124,17 +124,17 @@ function QboInvoiceCard({ detail }: { detail: InvoiceRow }) {
               </thead>
               <tbody className="divide-y">
                 {detail.line_items.map((item, idx) => (
-                  <tr key={idx} className="hover:bg-slate-50/50">
-                    <td className="p-2 text-slate-700 max-w-[200px] truncate" title={item.description || undefined}>
+                  <tr key={idx} className="hover:bg-muted/50">
+                    <td className="p-2 text-foreground max-w-[200px] truncate" title={item.description || undefined}>
                       {item.description || '—'}
                     </td>
-                    <td className="p-2 text-right text-slate-600">{item.quantity}</td>
-                    <td className="p-2 text-right text-slate-600">{formatCurrency(item.unit_price)}</td>
-                    <td className="p-2 text-right font-medium text-slate-800">{formatCurrency(item.amount)}</td>
+                    <td className="p-2 text-right text-muted-foreground">{item.quantity}</td>
+                    <td className="p-2 text-right text-muted-foreground">{formatCurrency(item.unit_price)}</td>
+                    <td className="p-2 text-right font-medium text-foreground">{formatCurrency(item.amount)}</td>
                   </tr>
                 ))}
               </tbody>
-              <tfoot className="border-t text-slate-600 text-xs">
+              <tfoot className="border-t text-muted-foreground text-xs">
                 <tr>
                   <td colSpan={3} className="p-2 text-right font-medium">
                     Subtotal
@@ -149,7 +149,7 @@ function QboInvoiceCard({ detail }: { detail: InvoiceRow }) {
                     <td className="p-2 text-right font-medium">{formatCurrency(detail.tax_total)}</td>
                   </tr>
                 )}
-                <tr className="text-slate-800 font-bold">
+                <tr className="text-foreground font-bold">
                   <td colSpan={3} className="p-2 text-right">
                     Total
                   </td>
@@ -162,7 +162,7 @@ function QboInvoiceCard({ detail }: { detail: InvoiceRow }) {
       )}
 
       {detail.synced_at && (
-        <div className="px-4 py-2 bg-slate-50 text-[11px] text-slate-400">
+        <div className="px-4 py-2 bg-muted text-[11px] text-muted-foreground">
           Synced {new Date(detail.synced_at).toLocaleDateString()}
         </div>
       )}
@@ -173,41 +173,41 @@ function QboInvoiceCard({ detail }: { detail: InvoiceRow }) {
 function ManualPaidQuoteCard({ row, locale }: { row: ManualPaidQuoteSnapshot; locale: string }) {
   const href = `/${locale}/quotes/${row.job_id}`
   return (
-    <Card className="border-emerald-200/80 overflow-hidden border-l-4 border-l-emerald-500 shadow-sm">
-      <div className="bg-gradient-to-r from-emerald-50/90 to-white p-4 border-b border-emerald-100/80 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+    <Card className="border-status-active/30 overflow-hidden border-l-4 border-l-status-active shadow-sm">
+      <div className="bg-gradient-to-r from-status-active/10 to-card p-4 border-b border-status-active/30 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div className="min-w-0 space-y-1">
           <div className="flex items-center gap-2 flex-wrap">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-status-active/15 text-status-active">
               <Banknote className="h-4 w-4" />
             </div>
-            <h3 className="text-base font-bold text-slate-800">{row.title}</h3>
-            <span className="text-xs text-slate-500">#{row.job_id}</span>
-            <Badge className="bg-emerald-100 text-emerald-800 border-emerald-200 font-semibold shadow-none">
+            <h3 className="text-base font-bold text-foreground">{row.title}</h3>
+            <span className="text-xs text-muted-foreground">#{row.job_id}</span>
+            <Badge className="bg-status-active/15 text-status-active border-status-active/30 font-semibold shadow-none">
               <CheckCircle2 className="w-3 h-3 mr-1" /> Paid · App only
             </Badge>
           </div>
-          {row.client_name && <p className="text-xs text-slate-600 pl-10 sm:pl-0">{row.client_name}</p>}
-          <p className="text-xs text-slate-500 pl-10 sm:pl-0">No QuickBooks invoice linked — counted as collected in the snapshot.</p>
+          {row.client_name && <p className="text-xs text-muted-foreground pl-10 sm:pl-0">{row.client_name}</p>}
+          <p className="text-xs text-muted-foreground pl-10 sm:pl-0">No QuickBooks invoice linked — counted as collected in the snapshot.</p>
         </div>
-        <Button variant="outline" size="sm" className="border-slate-200 shrink-0 h-8" asChild>
+        <Button variant="outline" size="sm" className="border-border shrink-0 h-8" asChild>
           <Link href={href}>
             <FileText className="w-3.5 h-3.5 mr-1" /> Open quote
           </Link>
         </Button>
       </div>
 
-      <div className="grid grid-cols-3 divide-x border-b border-slate-100 text-center">
+      <div className="grid grid-cols-3 divide-x border-b border-border text-center">
         <div className="p-3">
-          <p className="text-[10px] font-semibold text-slate-400 uppercase">Total</p>
-          <p className="text-lg font-bold text-slate-800 mt-0.5">{formatCurrency(row.total_amount)}</p>
+          <p className="text-[10px] font-semibold text-muted-foreground uppercase">Total</p>
+          <p className="text-lg font-bold text-foreground mt-0.5">{formatCurrency(row.total_amount)}</p>
         </div>
         <div className="p-3">
-          <p className="text-[10px] font-semibold text-emerald-600 uppercase">Paid</p>
-          <p className="text-lg font-bold text-emerald-600 mt-0.5">{formatCurrency(row.total_amount)}</p>
+          <p className="text-[10px] font-semibold text-status-active uppercase">Paid</p>
+          <p className="text-lg font-bold text-status-active mt-0.5">{formatCurrency(row.total_amount)}</p>
         </div>
         <div className="p-3">
-          <p className="text-[10px] font-semibold text-slate-400 uppercase">Due</p>
-          <p className="text-lg font-bold text-slate-400 mt-0.5">{formatCurrency(0)}</p>
+          <p className="text-[10px] font-semibold text-muted-foreground uppercase">Due</p>
+          <p className="text-lg font-bold text-muted-foreground mt-0.5">{formatCurrency(0)}</p>
         </div>
       </div>
     </Card>
@@ -226,12 +226,12 @@ function ManualPaidQuotesSection({
   if (rows.length === 0) return null
   return (
     <div className={className}>
-      <h3 className="text-sm font-semibold text-slate-800 flex items-center gap-2">
-        <Banknote className="w-4 h-4 text-emerald-600" />
+      <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
+        <Banknote className="w-4 h-4 text-status-active" />
         Other payments
-        <span className="text-slate-500 font-normal">(no QuickBooks invoice)</span>
+        <span className="text-muted-foreground font-normal">(no QuickBooks invoice)</span>
       </h3>
-      <p className="text-xs text-slate-500 mt-1 mb-3 max-w-xl">
+      <p className="text-xs text-muted-foreground mt-1 mb-3 max-w-xl">
         Paid quotes recorded in the app without a QuickBooks invoice id or link. Totals match the financial snapshot.
       </p>
       <div className="space-y-3">
@@ -292,18 +292,18 @@ export function SummaryInvoicingTab({ project, summary }: SummaryInvoicingTabPro
 
   if (qboLoading && !qboPayload) {
     qboSectionBody = (
-      <Card className="border-slate-200">
+      <Card className="border-border">
         <CardContent className="p-8 flex justify-center">
-          <Loader2 className="w-6 h-6 animate-spin text-orange-500" />
+          <Loader2 className="w-6 h-6 animate-spin text-primary" />
         </CardContent>
       </Card>
     )
   } else if (qboError) {
     qboSectionBody = (
-      <Card className="border-red-200 bg-red-50">
+      <Card className="border-destructive/30 bg-destructive/10">
         <CardContent className="p-6 text-center">
-          <AlertCircle className="w-6 h-6 text-red-400 mx-auto mb-2" />
-          <p className="text-sm text-red-600">{qboError}</p>
+          <AlertCircle className="w-6 h-6 text-destructive mx-auto mb-2" />
+          <p className="text-sm text-destructive">{qboError}</p>
           <Button variant="outline" size="sm" onClick={fetchQBODetail} className="mt-3">
             Try Again
           </Button>
@@ -314,14 +314,14 @@ export function SummaryInvoicingTab({ project, summary }: SummaryInvoicingTabPro
     const manual = qboPayload.manual_paid_quotes ?? []
     qboSectionBody = (
       <div className="space-y-6">
-        <Card className="border-dashed border-slate-300 bg-slate-50/80">
+        <Card className="border-dashed border-border bg-muted/80">
           <CardContent className="p-8 text-center space-y-4 max-w-lg mx-auto">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-500/10 text-blue-600">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
               <Link2 className="h-6 w-6" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-slate-800">Connect QuickBooks</p>
-              <p className="text-xs text-slate-500 mt-1">Settings → Integrations</p>
+              <p className="text-sm font-semibold text-foreground">Connect QuickBooks</p>
+              <p className="text-xs text-muted-foreground mt-1">Settings → Integrations</p>
             </div>
             <Button asChild>
               <Link href={settingsIntegrationsHref}>Connect</Link>
@@ -339,11 +339,11 @@ export function SummaryInvoicingTab({ project, summary }: SummaryInvoicingTabPro
 
     if (!hasQbo && !hasManual) {
       qboSectionBody = (
-        <Card className="border-dashed border-slate-300 bg-slate-50">
+        <Card className="border-dashed border-border bg-muted">
           <CardContent className="p-8 text-center space-y-2">
-            <FileText className="w-8 h-8 text-slate-300 mx-auto" />
-            <p className="text-sm font-medium text-slate-500">No QuickBooks invoices on linked quotes yet.</p>
-            <p className="text-xs text-slate-400 max-w-md mx-auto">
+            <FileText className="w-8 h-8 text-muted-foreground mx-auto" />
+            <p className="text-sm font-medium text-muted-foreground">No QuickBooks invoices on linked quotes yet.</p>
+            <p className="text-xs text-muted-foreground max-w-md mx-auto">
               When you sync invoices from QuickBooks, they appear here. Paid quotes without QuickBooks also list under
               Other payments when applicable.
             </p>
@@ -356,10 +356,10 @@ export function SummaryInvoicingTab({ project, summary }: SummaryInvoicingTabPro
           {hasQbo && (
             <div className="space-y-4">
               {qboPayload.multiple_invoices && (
-                <Alert className="border-amber-200 bg-amber-50/80 text-amber-950 py-3">
-                  <AlertCircle className="h-4 w-4 text-amber-700" />
-                  <AlertTitle className="text-amber-900 text-sm">{qboPayload.invoice_count} invoices</AlertTitle>
-                  <AlertDescription className="text-amber-900/90 text-xs">
+                <Alert className="border-status-pending/30 bg-status-pending/10 text-foreground py-3">
+                  <AlertCircle className="h-4 w-4 text-status-pending" />
+                  <AlertTitle className="text-status-pending text-sm">{qboPayload.invoice_count} invoices</AlertTitle>
+                  <AlertDescription className="text-status-pending/90 text-xs">
                     One card per linked quote; totals are separate.
                   </AlertDescription>
                 </Alert>
@@ -369,7 +369,7 @@ export function SummaryInvoicingTab({ project, summary }: SummaryInvoicingTabPro
               ))}
             </div>
           )}
-          <ManualPaidQuotesSection rows={manual} locale={locale} className={hasQbo ? 'pt-2 border-t border-slate-200' : undefined} />
+          <ManualPaidQuotesSection rows={manual} locale={locale} className={hasQbo ? 'pt-2 border-t border-border' : undefined} />
         </div>
       )
     }
@@ -378,41 +378,41 @@ export function SummaryInvoicingTab({ project, summary }: SummaryInvoicingTabPro
   return (
     <div className="p-6 space-y-8">
       <div className="space-y-4">
-        <h2 className="text-xl font-bold tracking-tight text-slate-800">Snapshot</h2>
+        <h2 className="text-xl font-bold tracking-tight text-foreground">Snapshot</h2>
 
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
-          <Card className="bg-amber-50 border-amber-100">
+          <Card className="bg-status-pending/10 border-status-pending/30">
             <CardContent className="p-4">
-              <p className="text-[10px] font-semibold text-amber-700 uppercase tracking-wide">Material Cost</p>
-              <p className="text-lg font-bold text-amber-700 mt-1 tabular-nums">{formatCurrency(summary.total_materials)}</p>
+              <p className="text-[10px] font-semibold text-status-pending uppercase tracking-wide">Material Cost</p>
+              <p className="text-lg font-bold text-status-pending mt-1 tabular-nums">{formatCurrency(summary.total_materials)}</p>
             </CardContent>
           </Card>
 
-          <Card className="bg-slate-50 border-slate-200">
+          <Card className="bg-muted border-border">
             <CardContent className="p-4">
-              <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide">{companyName} Cost</p>
-              <p className="text-lg font-bold text-slate-700 mt-1 tabular-nums">{formatCurrency(summary.total_cost_items)}</p>
+              <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">{companyName} Cost</p>
+              <p className="text-lg font-bold text-foreground mt-1 tabular-nums">{formatCurrency(summary.total_cost_items)}</p>
             </CardContent>
           </Card>
 
-          <Card className="bg-orange-50 border-orange-100">
+          <Card className="bg-primary/10 border-primary/30">
             <CardContent className="p-4">
-              <p className="text-[10px] font-semibold text-orange-600 uppercase tracking-wide">Total Invoiced</p>
-              <p className="text-lg font-bold text-orange-600 mt-1 tabular-nums">{formatCurrency(summary.total_invoiced)}</p>
+              <p className="text-[10px] font-semibold text-primary uppercase tracking-wide">Total Invoiced</p>
+              <p className="text-lg font-bold text-primary mt-1 tabular-nums">{formatCurrency(summary.total_invoiced)}</p>
             </CardContent>
           </Card>
 
-          <Card className="bg-emerald-50 border-emerald-100">
+          <Card className="bg-status-active/10 border-status-active/30">
             <CardContent className="p-4">
-              <p className="text-[10px] font-semibold text-emerald-700 uppercase tracking-wide">Collected</p>
-              <p className="text-lg font-bold text-emerald-600 mt-1 tabular-nums">{formatCurrency(summary.total_paid)}</p>
+              <p className="text-[10px] font-semibold text-status-active uppercase tracking-wide">Collected</p>
+              <p className="text-lg font-bold text-status-active mt-1 tabular-nums">{formatCurrency(summary.total_paid)}</p>
             </CardContent>
           </Card>
 
-          <Card className="bg-blue-50 border-blue-100">
+          <Card className="bg-primary/10 border-primary/20">
             <CardContent className="p-4">
-              <p className="text-[10px] font-semibold text-blue-600 uppercase tracking-wide">{companyName} Profit</p>
-              <p className="text-lg font-bold text-blue-600 mt-1 tabular-nums">{formatCurrency(summary.profit_to_date)}</p>
+              <p className="text-[10px] font-semibold text-primary uppercase tracking-wide">{companyName} Profit</p>
+              <p className="text-lg font-bold text-primary mt-1 tabular-nums">{formatCurrency(summary.profit_to_date)}</p>
             </CardContent>
           </Card>
         </div>
@@ -420,13 +420,13 @@ export function SummaryInvoicingTab({ project, summary }: SummaryInvoicingTabPro
 
       <div className="space-y-4">
         <div className="flex items-center justify-between gap-2">
-          <h2 className="text-xl font-bold tracking-tight text-slate-800">QuickBooks</h2>
+          <h2 className="text-xl font-bold tracking-tight text-foreground">QuickBooks</h2>
           <Button
             variant="ghost"
             size="icon"
             onClick={fetchQBODetail}
             disabled={qboLoading}
-            className="text-slate-500 hover:text-slate-700 shrink-0 h-9 w-9"
+            className="text-muted-foreground hover:text-foreground shrink-0 h-9 w-9"
             title="Refresh"
             aria-label="Refresh QuickBooks data"
           >

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -20,6 +20,8 @@ import type {
   User,
   PaymentSchedule,
   PaymentScheduleLineInput,
+  ProjectFinancialSummary,
+  ProjectScopeBilling,
 } from './types'
 import type { AutoReplySettings, TwilioAvailableNumber, TwilioProvisionResult } from './types/twilio'
 import type {
@@ -2418,8 +2420,13 @@ class ApiClient {
     })
   }
 
-  async getProjectFinancialSummary(projectId: number) {
-    return this.request<any>(`/projects/${projectId}/financials/summary`)
+  async getProjectFinancialSummary(projectId: number): Promise<ProjectFinancialSummary> {
+    return this.request<ProjectFinancialSummary>(`/projects/${projectId}/financials/summary`)
+  }
+
+  /** Scope → draws → invoices for the project, reconciled in one payload. */
+  async getProjectScopeBilling(projectId: number): Promise<ProjectScopeBilling> {
+    return this.request<ProjectScopeBilling>(`/projects/${projectId}/financials/scope`)
   }
 
   async getCampaigns(): Promise<Campaign[]> {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1297,6 +1297,7 @@ export interface ProjectCostItem {
   client_price: number
   owed_to_sub: number
   paid: number
+  source_job_item_id?: number | null  // quote line this was seeded from
   order: number
   created_at: string
   updated_at?: string
@@ -1328,6 +1329,7 @@ export interface ProjectMaterial {
   client_price: number
   po_url?: string | null
   receipts?: { name: string; url: string }[]
+  source_job_item_id?: number | null  // quote line this was seeded from
   order: number
   created_at: string
   updated_at?: string
@@ -1383,6 +1385,95 @@ export interface ProjectFinancialSummary {
   collected_pct: number
   approved_co_total: number
   adjusted_budget: number
+
+  // --- Contract reconciliation (single source of truth) ---
+  /** Anchor quote's live grand total (scope-derived). */
+  base_contract_total?: number
+  /** base_contract + approved change orders. */
+  derived_contract_total?: number
+  /** Where the contract total comes from: 'override' | 'quote' | 'none'. */
+  contract_source?: 'override' | 'quote' | 'none'
+  /** True when project.contract_value was set manually (overrides the quote). */
+  contract_overridden?: boolean
+  /** override − derived (0 when not overridden). Non-zero = drift to flag. */
+  contract_drift?: number
+  /** The quote the contract derives from. */
+  anchor_job_id?: number | null
+}
+
+// ── Scope & Billing: quote line items → draws → invoices, reconciled ──
+export interface ScopeQuoteLineItem {
+  id: number
+  description: string
+  quantity: number
+  unit_of_measure?: string | null
+  unit_price: number
+  total: number          // client price (with markup)
+  cost: number           // pre-markup cost basis (seeds gc_cost / material cost)
+  is_taxable: boolean
+}
+export interface ScopeQuote {
+  job_id: number
+  title: string
+  job_number?: string | null
+  status: string
+  is_anchor: boolean
+  is_change_order: boolean
+  /** Part of the contract (anchor or approved). False for draft/rejected/superseded
+   *  quotes — the picker blocks pulling scope from those. */
+  counts_toward_contract: boolean
+  grand_total: number
+  line_items: ScopeQuoteLineItem[]
+}
+export interface ScopeInvoice {
+  id: number
+  invoice_number: string
+  job_id: number | null
+  title?: string | null
+  status: string | null
+  total_amount: number
+  amount_paid: number
+  balance_due: number
+  issue_date?: string | null
+  due_date?: string | null
+  is_draw: boolean
+}
+/** A draw schedule plus the quote it belongs to — a project can have several
+ * (one per genuine contract / change order), so schedules are returned as a list. */
+export interface ScopeSchedule extends PaymentSchedule {
+  quote_title: string
+  status: string | null
+  is_anchor: boolean
+  is_change_order: boolean
+  /** False when the quote has no draw schedule — the whole `contract_total` is
+   * payable as a single payment (`lines` is empty). */
+  has_draws: boolean
+}
+export interface ProjectScopeBilling {
+  contract: {
+    anchor_job_id: number | null
+    base_contract: number
+    approved_co_total: number
+    derived_total: number
+    override: number | null
+    contract_total: number
+    source: 'override' | 'quote' | 'none'
+    drift: number
+  }
+  quotes: ScopeQuote[]
+  /** Back-compat: the anchor quote's schedule. Prefer `schedules`. */
+  schedule: ScopeSchedule | null
+  /** One schedule per linked quote that has draws (anchor first). */
+  schedules: ScopeSchedule[]
+  invoices: ScopeInvoice[]
+  reconciliation: {
+    contract_total: number
+    scheduled_total: number
+    invoiced_total: number
+    collected_total: number
+    uninvoiced_remaining: number
+    unbilled_in_schedule: number
+  }
 }
 
 // ============================================


### PR DESCRIPTION


Depends on backend Issue#66 (GET /projects/{id}/financials/scope + the add_cost_item_quote_link migration) -- deploy AFTER the backend is merged and migrated; Scope & Billing is the default tab and calls that endpoint on mount.

Scope & Billing (new default tab)
- New scope-billing-tab.tsx: reconciliation banner (contract / scheduled / invoiced / collected, over-invoiced aware) + quotes -> line items -> per-quote draw schedules -> invoices. Read-only with link-outs to quotes/invoices in a new tab; keyboard-activatable invoice rows.

Add from quote
- New quote-item-picker.tsx: pull quote line items into Job Costing / Materials (seeds gc_cost/cost + client_price, stores source_job_item_id). Already-pulled items are greyed; non-contract (draft/rejected) quotes are disabled so scope the contract excludes can't be pulled. Partial-failure safe -- commits rows that did save and keeps the dialog open on error, so nothing is lost or duplicated.

Other changes
- Job Costing subcontractor dropdown now loads the full subcontractor directory (was: only subs already attached to a project trade).
- Sidebar: contract-drift flag + green/yellow over-budget bar.
- Move all 8 financials components onto design tokens (orange -> blue primary, dark-mode-safe).
- Add MoneyInput (money-input.tsx): plain text money field (no number spinners, decimal keypad on mobile, commits on blur/Enter), used by the Job Costing and Materials cost cells.
- Types/api: ProjectScopeBilling / ScopeQuote / ScopeSchedule / ScopeInvoice (incl. counts_toward_contract and source_job_item_id); typed getProjectFinancialSummary and getProjectScopeBilling.