### PR TITLE
Add team management UI, attribution display, and invoice send (email/…

### DIFF
--- a/app/[locale]/(public)/invite/[token]/page.tsx
+++ b/app/[locale]/(public)/invite/[token]/page.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { useLocale } from "next-intl"
+import { api } from "@/lib/api"
+import type { InviteInfo } from "@/lib/types"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { AuthPasswordInput } from "@/app/[locale]/auth/_components/auth-password-input"
+import { Users, Loader2, AlertCircle } from "lucide-react"
+
+export default function InviteAcceptPage() {
+  const params = useParams()
+  const router = useRouter()
+  const locale = useLocale()
+  const token = params.token as string
+
+  const [info, setInfo] = useState<InviteInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [fullName, setFullName] = useState("")
+  const [password, setPassword] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+    api
+      .getInvite(token)
+      .then(setInfo)
+      .catch(() => setInfo({ valid: false }))
+      .finally(() => setLoading(false))
+  }, [token])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.")
+      return
+    }
+    setSubmitting(true)
+    try {
+      await api.acceptInvite(token, fullName.trim(), password)
+      // Session cookie is set by the backend; land in the app.
+      router.push(`/${locale}/dashboard`)
+    } catch (err: any) {
+      setError(err.message || "Couldn't accept the invite.")
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50">
+        <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+      </div>
+    )
+  }
+
+  if (!info?.valid) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+        <div className="w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-sm border border-slate-100">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-50">
+            <AlertCircle className="h-6 w-6 text-red-500" />
+          </div>
+          <h1 className="text-lg font-semibold text-slate-900">
+            {info?.already_accepted ? "Invite already used" : "Invite not valid"}
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {info?.already_accepted
+              ? "This invite has already been accepted. Try logging in instead."
+              : "This invite link is invalid or has expired. Ask your team admin to send a new one."}
+          </p>
+          <Button
+            className="mt-6 w-full bg-slate-900 hover:bg-slate-700"
+            onClick={() => router.push(`/${locale}/auth/login`)}
+          >
+            Go to login
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-sm border border-slate-100">
+        <div className="mb-6 text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-slate-900 text-white">
+            <Users className="h-6 w-6" />
+          </div>
+          <h1 className="text-xl font-semibold text-slate-900">
+            Join {info.company_name || "the team"}
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            You've been invited as {info.invited_email}. Set up your account to get started.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="full_name">Your name</Label>
+            <Input
+              id="full_name"
+              required
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              placeholder="Jane Doe"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label htmlFor="password">Password</Label>
+            <AuthPasswordInput
+              id="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="At least 8 characters"
+              className="mt-1"
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <Button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-slate-900 hover:bg-slate-700"
+          >
+            {submitting ? "Setting up…" : "Join team"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/app/[locale]/quotes/page.tsx
+++ b/app/[locale]/quotes/page.tsx
@@ -34,7 +34,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { useToast } from "@/hooks/use-toast"
 import { api } from "@/lib/api"
-import { FileText, Plus, Search, Trash2, ChevronDown, FolderOpen, Unlink } from "lucide-react"
+import { FileText, Plus, Search, Trash2, ChevronDown, FolderOpen, Unlink, Mail, Phone, MapPin, CalendarDays, UserRound } from "lucide-react"
 import { NewProjectDialog } from "@/components/projects/new-project-dialog"
 
 interface ClientInfo {
@@ -58,6 +58,8 @@ interface Quote {
   project_id?: number | null
   project_title?: string | null
   has_proposal?: boolean
+  created_by_name?: string | null
+  created_by_user_id?: number | null
 }
 
 const ITEMS_PER_PAGE = 10
@@ -680,23 +682,47 @@ export default function QuotesPage() {
                           </DropdownMenu>
                         )}
                       </div>
-                      <h3 className="text-base font-semibold text-foreground group-hover:text-primary transition-colors truncate">
-                        {quote.client?.name || "Unknown client"}
+                      <h3 className="flex items-center gap-1.5 text-base font-semibold text-foreground group-hover:text-primary transition-colors truncate">
+                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                          <UserRound className="h-3 w-3" />
+                        </span>
+                        <span className="truncate">{quote.client?.name || "Unknown client"}</span>
                       </h3>
                       {quote.title?.trim() && (
-                        <p className="text-sm text-muted-foreground line-clamp-1">{quote.title}</p>
+                        <p className="text-sm text-muted-foreground line-clamp-1 pl-7">{quote.title}</p>
                       )}
-                      <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
-                        {quote.client?.email && <span className="truncate max-w-full">{quote.client.email}</span>}
-                        {quote.client?.phone && <span>{quote.client.phone}</span>}
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                        {quote.client?.email && (
+                          <span className="inline-flex items-center gap-1 truncate max-w-full">
+                            <Mail className="h-3 w-3 shrink-0 opacity-70" />
+                            {quote.client.email}
+                          </span>
+                        )}
+                        {quote.client?.phone && (
+                          <span className="inline-flex items-center gap-1">
+                            <Phone className="h-3 w-3 shrink-0 opacity-70" />
+                            {quote.client.phone}
+                          </span>
+                        )}
+                        {quote.client?.address && (
+                          <span className="inline-flex items-center gap-1 truncate max-w-full">
+                            <MapPin className="h-3 w-3 shrink-0 opacity-70" />
+                            {quote.client.address}
+                          </span>
+                        )}
                       </div>
-                      {quote.client?.address && (
-                        <p className="text-xs text-muted-foreground line-clamp-1">{quote.client.address}</p>
-                      )}
-                      <p className="text-[11px] text-muted-foreground pt-0.5">
-                        Created {formatDate(quote.created_at)}
-                        {quote.updated_at && ` · Updated ${formatDate(quote.updated_at)}`}
-                      </p>
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground pt-0.5">
+                        <span className="inline-flex items-center gap-1">
+                          <CalendarDays className="h-3 w-3 shrink-0 opacity-70" />
+                          {formatDate(quote.created_at)}
+                        </span>
+                        {quote.created_by_name && (
+                          <span className="inline-flex items-center gap-1">
+                            <UserRound className="h-3 w-3 shrink-0 opacity-70" />
+                            {quote.created_by_name}
+                          </span>
+                        )}
+                      </div>
                     </div>
                     <div className="flex flex-col items-end gap-1.5 shrink-0">
                       <span className="text-[11px] font-medium text-muted-foreground tabular-nums">

--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -64,6 +64,9 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     // Public client portal (no auth required)
     pathname?.match(/^\/[a-z]{2}\/client\//) || // Matches /en/client/{token}, /es/client/{token}
     pathname?.startsWith("/client/") || // Legacy non-i18n routes
+    // Team invite acceptance (invited users are logged out by definition)
+    pathname?.match(/^\/[a-z]{2}\/invite\//) || // Matches /en/invite/{token}, /es/invite/{token}
+    pathname?.startsWith("/invite/") || // Legacy non-i18n routes
     // Public crew (subcontractor) portal (no auth required)
     pathname?.match(/^\/[a-z]{2}\/crew\/portal\//) || // Matches /en/crew/portal/{uuid}, /es/crew/portal/{uuid}
     pathname?.startsWith("/crew/portal/") // Legacy non-i18n routes

--- a/components/conditional-shell.tsx
+++ b/components/conditional-shell.tsx
@@ -32,6 +32,9 @@ function isPublicShellRoute(pathname: string): boolean {
     // Public client portal — no contractor shell
     !!pathname?.match(/^\/[a-z]{2}\/client\//) ||
     pathname?.startsWith("/client/") ||
+    // Team invite acceptance — no contractor shell
+    !!pathname?.match(/^\/[a-z]{2}\/invite\//) ||
+    pathname?.startsWith("/invite/") ||
     // Public crew (subcontractor) portal — no contractor shell
     !!pathname?.match(/^\/[a-z]{2}\/crew\/portal\//) ||
     pathname?.startsWith("/crew/portal/") ||

--- a/components/invoice-detail.tsx
+++ b/components/invoice-detail.tsx
@@ -24,8 +24,17 @@ import { useLocale } from "next-intl"
 import Link from "next/link"
 import Image from "next/image"
 import { Badge } from "@/components/ui/badge"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { cleanAddressString } from "@/lib/format-address"
-import { ChevronDown } from "lucide-react"
+import { ChevronDown, Send, Mail, MessageSquare, Link2, Check, Loader2 } from "lucide-react"
+import { useAuth } from "@/contexts/AuthContext"
+import { ClientSendSmsDialog } from "@/components/client-send-sms-dialog"
 import { ClientDocumentNav, clientDocumentNavContentClassName } from "@/components/client-document-nav"
 import { useClientPortalDocuments } from "@/hooks/use-client-portal-documents"
 import { buildClientDocumentNavProps } from "@/lib/client-portal-nav"
@@ -90,7 +99,11 @@ export function InvoiceDetail({ invoiceId, publicLink }: { invoiceId?: string; p
   const [sendingEmail, setSendingEmail] = useState(false)
   const [updatingStatus, setUpdatingStatus] = useState(false)
   const [lineItemsOpen, setLineItemsOpen] = useState(false)
+  const [copiedLink, setCopiedLink] = useState(false)
+  const [generatingLink, setGeneratingLink] = useState(false)
+  const [showSmsDialog, setShowSmsDialog] = useState(false)
   const { toast } = useToast()
+  const { getContractorAISpId } = useAuth()
   const locale = useLocale()
   // In the public view the portal token rides along in the invoice payload, so
   // the sidebar (sibling quote + proposal + "My Portal") is driven by the same
@@ -164,7 +177,8 @@ export function InvoiceDetail({ invoiceId, publicLink }: { invoiceId?: string; p
     if (!invoice) return
     setSendingEmail(true)
     try {
-      const result = await api.sendInvoiceViaEmail(invoice.id)
+      const base = typeof window !== "undefined" ? `${window.location.origin}/${locale}` : undefined
+      const result = await api.sendInvoiceViaEmail(invoice.id, base)
       toast({ title: "Invoice sent", description: result.message })
       await fetchInvoice()
     } catch (err: any) {
@@ -177,6 +191,46 @@ export function InvoiceDetail({ invoiceId, publicLink }: { invoiceId?: string; p
       setSendingEmail(false)
     }
   }
+
+  const buildInvoiceUrl = (publicLinkValue: string) =>
+    `${typeof window !== "undefined" ? window.location.origin : ""}/${locale}/invoices/${publicLinkValue}`
+
+  const handleCopyInvoiceLink = async () => {
+    if (!invoice) return
+    setGeneratingLink(true)
+    try {
+      let link: string = invoice.public_link
+      if (!link) {
+        const res = await api.ensureInvoicePublicLink(invoice.id)
+        link = res.public_link
+        setInvoice((prev: any) => (prev ? { ...prev, public_link: link } : prev))
+      }
+      await navigator.clipboard.writeText(buildInvoiceUrl(link))
+      setCopiedLink(true)
+      setTimeout(() => setCopiedLink(false), 2000)
+    } catch (err: any) {
+      toast({ title: "Couldn't copy link", description: err?.message, variant: "destructive" })
+    } finally {
+      setGeneratingLink(false)
+    }
+  }
+
+  const handleOpenSms = async () => {
+    if (!invoice) return
+    if (!invoice.public_link) {
+      try {
+        const res = await api.ensureInvoicePublicLink(invoice.id)
+        setInvoice((prev: any) => (prev ? { ...prev, public_link: res.public_link } : prev))
+      } catch {
+        // proceed even if link generation fails; message just omits the link
+      }
+    }
+    setShowSmsDialog(true)
+  }
+
+  const smsPresetMessage = invoice
+    ? `Hi ${invoice.client_name || "there"}, here's your invoice${invoice.contractor_company_name ? ` from ${invoice.contractor_company_name}` : ""}${invoice.public_link ? `: ${buildInvoiceUrl(invoice.public_link)}` : "."}`
+    : ""
 
   const handleStatusChange = async (newStatus: string) => {
     if (!invoice) return
@@ -630,24 +684,52 @@ export function InvoiceDetail({ invoiceId, publicLink }: { invoiceId?: string; p
                 </Button>
               )}
 
-              {/* Send to Client */}
-              <Button
-                size="lg"
-                className="w-full justify-start h-12 text-base"
-                variant="outline"
-                onClick={handleSendEmail}
-                disabled={sendingEmail}
-              >
-                <svg className="mr-3 h-5 w-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                  />
-                </svg>
-                {sendingEmail ? "Sending…" : "Send to Client"}
-              </Button>
+              {/* Send to Client — Email / SMS / Copy link */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="lg"
+                    className="w-full justify-start h-12 text-base"
+                    variant="outline"
+                    disabled={sendingEmail}
+                  >
+                    {sendingEmail ? (
+                      <Loader2 className="mr-3 h-5 w-5 shrink-0 animate-spin" />
+                    ) : (
+                      <Send className="mr-3 h-5 w-5 shrink-0" />
+                    )}
+                    {sendingEmail ? "Sending…" : "Send to Client"}
+                    <ChevronDown className="ml-auto h-4 w-4 shrink-0 opacity-60" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-56">
+                  <DropdownMenuItem
+                    onClick={handleSendEmail}
+                    disabled={sendingEmail || !invoice.client_email}
+                  >
+                    <Mail className="mr-2 h-4 w-4 text-slate-500" />
+                    Send via Email
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={handleOpenSms}
+                    disabled={!invoice.client_phone || !getContractorAISpId()}
+                  >
+                    <MessageSquare className="mr-2 h-4 w-4 text-slate-500" />
+                    Send via SMS
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleCopyInvoiceLink} disabled={generatingLink}>
+                    {copiedLink ? (
+                      <Check className="mr-2 h-4 w-4 text-emerald-600" />
+                    ) : generatingLink ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Link2 className="mr-2 h-4 w-4 text-slate-500" />
+                    )}
+                    {copiedLink ? "Copied!" : "Copy invoice link"}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
 
               {/* Print */}
               <Button
@@ -792,6 +874,19 @@ export function InvoiceDetail({ invoiceId, publicLink }: { invoiceId?: string; p
           </div>
         </DialogContent>
       </Dialog>
+      )}
+
+      {!publicMode && invoice && getContractorAISpId() && invoice.client_phone && (
+        <ClientSendSmsDialog
+          key={invoice.public_link || "no-link"}
+          open={showSmsDialog}
+          onOpenChange={setShowSmsDialog}
+          spId={getContractorAISpId() as number}
+          clientName={invoice.client_name || ""}
+          clientPhone={invoice.client_phone}
+          clientId={invoice.client_id}
+          presetMessage={smsPresetMessage}
+        />
       )}
     </div>
     </div>

--- a/components/personalized-quote-view.tsx
+++ b/components/personalized-quote-view.tsx
@@ -17,7 +17,7 @@ import {
   DialogTrigger,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Check, ChevronDown, Clock3, ExternalLink, FileText, MessageSquareMore, PencilLine, Printer, Send, Sparkles, Trash2 } from "lucide-react"
+import { Check, ChevronDown, Clock3, ExternalLink, FileText, MessageSquareMore, PencilLine, Printer, Send, Sparkles, Trash2, UserRound } from "lucide-react"
 import Link from "next/link"
 import { api } from "@/lib/api"
 import { cn, formatPhoneForDisplay } from "@/lib/utils"
@@ -322,6 +322,20 @@ export function PersonalizedQuoteView({
       year: 'numeric',
       month: 'long',
       day: 'numeric'
+    })
+  }
+
+  // Full timestamp converted to the viewer's local timezone (date + time).
+  const formatDateTimeLocal = (dateString?: string) => {
+    if (!dateString) return ""
+    const d = new Date(dateString)
+    if (isNaN(d.getTime())) return ""
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
     })
   }
 
@@ -1370,6 +1384,29 @@ export function PersonalizedQuoteView({
           {showActions && !isPublicView && (
             <div className="w-full lg:w-72 xl:w-80 lg:flex-shrink-0 print:hidden">
               <div className="lg:sticky lg:top-8 space-y-4">
+                {/* Created by — clean attribution + local-time stamp */}
+                {isContractor && (currentJob.created_by_name || currentJob.created_at) && (
+                  <div className="rounded-xl border border-slate-100 bg-white px-3 py-2.5 shadow-sm">
+                    {currentJob.created_by_name && (
+                      <div className="flex items-center gap-2">
+                        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-slate-900 text-white">
+                          <UserRound className="h-3.5 w-3.5" />
+                        </span>
+                        <div className="min-w-0">
+                          <div className="text-[10px] uppercase tracking-wide text-slate-400">Created by</div>
+                          <div className="truncate text-sm font-medium text-slate-800">{currentJob.created_by_name}</div>
+                        </div>
+                      </div>
+                    )}
+                    {currentJob.created_at && (
+                      <div className="mt-2 flex items-center gap-1.5 text-xs text-slate-500">
+                        <Clock3 className="h-3 w-3 shrink-0 opacity-70" />
+                        {formatDateTimeLocal(currentJob.created_at)}
+                      </div>
+                    )}
+                  </div>
+                )}
+
                 {/* Proposals — featured card, above Change Orders */}
                 {isContractor && (
                   <QuoteProposalsSection

--- a/components/settings-tabs.tsx
+++ b/components/settings-tabs.tsx
@@ -13,7 +13,7 @@ import { useAuth } from "@/contexts/AuthContext"
 import { LanguageSelector } from "@/components/language-selector"
 import { useTranslations } from "next-intl"
 import Image from "next/image"
-import { LogOut, CreditCard, ExternalLink, Copy, Building2, Globe, Phone, MapPin, DollarSign, Percent, Info, Pencil, Link2, Unlink, X, MessageSquare } from "lucide-react"
+import { LogOut, CreditCard, ExternalLink, Copy, Building2, Globe, Phone, MapPin, DollarSign, Percent, Info, Pencil, Link2, Unlink, X, MessageSquare, Users } from "lucide-react"
 import { useSearchParams } from "next/navigation"
 import { useLocale } from "next-intl"
 import { formatPhoneForDisplay } from "@/lib/utils"
@@ -21,11 +21,12 @@ import { useContractorOpsNumber } from "@/hooks/useContractorOpsNumber"
 
 import { CostBookSettings } from "@/components/cost-book-settings"
 import { AutoReplySettings } from "@/components/auto-reply-settings"
+import { TeamSettings } from "@/components/team-settings"
 import { MapboxAddressInput } from "@/components/mapbox-address-input"
 import { MobileDarkModeToggle } from "@/components/mobile-dark-mode-toggle"
 import { AddressData } from "@/lib/types/address"
 
-type SettingsSection = "business" | "billing" | "integrations" | "language" | "cost-book" | "auto-reply"
+type SettingsSection = "business" | "billing" | "integrations" | "language" | "cost-book" | "auto-reply" | "team"
 
 // Skeleton component for loading states
 function SettingsSkeleton() {
@@ -136,6 +137,9 @@ function SettingsSkeleton() {
 
 export function SettingsTabs() {
   const { user, logout } = useAuth()
+  // Only the account owner manages billing. Default to showing it unless the
+  // user is explicitly a non-owner (ADMIN/MEMBER), so owners are never blocked.
+  const canSeeBilling = user?.role !== "ADMIN" && user?.role !== "MEMBER"
   const locale = useLocale()
   const t = useTranslations('settings')
   const tAuth = useTranslations('auth')
@@ -203,7 +207,7 @@ export function SettingsTabs() {
 
   useEffect(() => {
     const tab = searchParams.get("tab") as SettingsSection
-    if (tab && ["business", "billing", "integrations", "language", "cost-book", "auto-reply"].includes(tab)) {
+    if (tab && ["business", "billing", "integrations", "language", "cost-book", "auto-reply", "team"].includes(tab)) {
       setActiveSection(tab)
     }
   }, [searchParams])
@@ -457,7 +461,8 @@ export function SettingsTabs() {
       ? []
       : [{ id: "auto-reply" as const, label: "Auto-reply", icon: MessageSquare }]),
     { id: "cost-book" as const, label: "Cost Book", icon: DollarSign },
-    { id: "billing" as const, label: "Billing", icon: CreditCard },
+    { id: "team" as const, label: "Team", icon: Users },
+    ...(canSeeBilling ? [{ id: "billing" as const, label: "Billing", icon: CreditCard }] : []),
     { id: "integrations" as const, label: "Integrations", icon: Link2 },
     { id: "language" as const, label: t('language'), icon: Globe },
   ]
@@ -601,6 +606,20 @@ export function SettingsTabs() {
                               className="h-10 border-slate-200"
                             />
                           </div>
+                        </div>
+
+                        <div className="space-y-2">
+                          <Label htmlFor="account-email" className="text-xs font-semibold text-slate-500 uppercase tracking-wide">
+                            Account email (login)
+                          </Label>
+                          <Input
+                            id="account-email"
+                            type="email"
+                            value={user?.email || ""}
+                            readOnly
+                            disabled
+                            className="h-10 bg-slate-50 border-slate-200 text-slate-600"
+                          />
                         </div>
 
                         <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2">
@@ -1204,7 +1223,7 @@ export function SettingsTabs() {
             )}
 
             {/* Billing Section */}
-            {activeSection === "billing" && (
+            {activeSection === "billing" && canSeeBilling && (
               <div className="bg-white rounded-xl shadow-sm border border-slate-100 overflow-hidden">
                 <div className="p-4 sm:p-6">
                   <h3 className="text-base sm:text-lg font-semibold text-slate-900 mb-4">Subscription</h3>
@@ -1333,6 +1352,11 @@ export function SettingsTabs() {
             {/* Cost Book Section */}
             {activeSection === "cost-book" && (
               <CostBookSettings />
+            )}
+
+            {/* Team Section */}
+            {activeSection === "team" && (
+              <TeamSettings />
             )}
 
             {/* Auto-reply Section — hidden entirely when Frontline is enabled */}

--- a/components/team-settings.tsx
+++ b/components/team-settings.tsx
@@ -1,0 +1,226 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useLocale } from "next-intl"
+import { api } from "@/lib/api"
+import type { TeamMember } from "@/lib/types"
+import { useToast } from "@/hooks/use-toast"
+import { Users, Mail, Copy, Check, Trash2, Crown, Shield, Clock } from "lucide-react"
+
+function RoleBadge({ role }: { role: TeamMember["role"] }) {
+  if (role === "OWNER") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+        <Crown className="h-3 w-3" /> Owner
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600">
+      <Shield className="h-3 w-3" /> {role.charAt(0) + role.slice(1).toLowerCase()}
+    </span>
+  )
+}
+
+export function TeamSettings() {
+  const { toast } = useToast()
+  const locale = useLocale()
+  const [members, setMembers] = useState<TeamMember[]>([])
+  const [loading, setLoading] = useState(true)
+  const [email, setEmail] = useState("")
+  const [inviting, setInviting] = useState(false)
+  const [lastInviteUrl, setLastInviteUrl] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [copiedId, setCopiedId] = useState<number | null>(null)
+
+  const buildInviteUrl = (token: string) =>
+    `${typeof window !== "undefined" ? window.location.origin : ""}/${locale}/invite/${token}`
+
+  const load = async () => {
+    try {
+      const data = await api.listTeamMembers()
+      setMembers(data)
+    } catch (err: any) {
+      toast({ title: "Couldn't load team", description: err.message, variant: "destructive" })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleInvite = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = email.trim()
+    if (!trimmed) return
+    setInviting(true)
+    try {
+      // Pass the current origin+locale so the emailed link uses the right host.
+      const base = typeof window !== "undefined" ? `${window.location.origin}/${locale}` : undefined
+      const res = await api.inviteTeamMember(trimmed, "ADMIN", base)
+      setLastInviteUrl(buildInviteUrl(res.invite_token))
+      setCopied(false)
+      setEmail("")
+      toast({ title: "Invite sent", description: `We emailed an invite to ${trimmed}. You can also copy the link below.` })
+      load()
+    } catch (err: any) {
+      toast({ title: "Couldn't send invite", description: err.message, variant: "destructive" })
+    } finally {
+      setInviting(false)
+    }
+  }
+
+  const copyLink = async () => {
+    if (!lastInviteUrl) return
+    try {
+      await navigator.clipboard.writeText(lastInviteUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast({ title: "Copy failed", description: "Select and copy the link manually.", variant: "destructive" })
+    }
+  }
+
+  const copyInviteLink = async (member: TeamMember) => {
+    if (!member.invite_token) return
+    try {
+      await navigator.clipboard.writeText(buildInviteUrl(member.invite_token))
+      setCopiedId(member.id)
+      setTimeout(() => setCopiedId(null), 2000)
+    } catch {
+      toast({ title: "Copy failed", description: "Copy the link manually.", variant: "destructive" })
+    }
+  }
+
+  const handleRemove = async (member: TeamMember) => {
+    if (!confirm(`Remove ${member.full_name || member.invited_email} from the team?`)) return
+    try {
+      await api.removeTeamMember(member.id)
+      toast({ title: "Removed" })
+      setMembers((prev) => prev.filter((m) => m.id !== member.id))
+    } catch (err: any) {
+      toast({ title: "Couldn't remove", description: err.message, variant: "destructive" })
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-100 overflow-hidden">
+      <div className="p-4 sm:p-6 space-y-6">
+        {/* Header */}
+        <div className="flex items-center gap-2">
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-slate-900 text-white">
+            <Users className="h-4.5 w-4.5" />
+          </div>
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">Team members</h2>
+            <p className="text-xs text-slate-500">Invite people to your account. They get full access.</p>
+          </div>
+        </div>
+
+        {/* Invite form */}
+        <form onSubmit={handleInvite} className="flex flex-col sm:flex-row gap-2">
+          <div className="relative flex-1">
+            <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+            <Input
+              type="email"
+              required
+              placeholder="teammate@company.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <Button type="submit" disabled={inviting} className="bg-slate-900 hover:bg-slate-700">
+            {inviting ? "Inviting…" : "Invite"}
+          </Button>
+        </form>
+
+        {/* Generated invite link */}
+        {lastInviteUrl && (
+          <div className="rounded-lg border border-sky-100 bg-sky-50 p-3">
+            <p className="text-xs font-medium text-slate-700 mb-1.5">Invite link — share it with your teammate:</p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 truncate rounded bg-white px-2 py-1.5 text-[11px] text-slate-600 border border-slate-200">
+                {lastInviteUrl}
+              </code>
+              <Button type="button" size="sm" variant="outline" onClick={copyLink} className="shrink-0">
+                {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
+                <span className="ml-1">{copied ? "Copied" : "Copy"}</span>
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Member list */}
+        <div className="space-y-1.5">
+          {loading ? (
+            <p className="text-sm text-slate-400 py-4 text-center">Loading…</p>
+          ) : members.length === 0 ? (
+            <p className="text-sm text-slate-400 py-4 text-center">No team members yet.</p>
+          ) : (
+            members.map((m) => {
+              const pending = m.status === "INVITED"
+              const name = m.full_name || m.invited_email || "Pending invite"
+              // Only show the sub-line once the member has accepted (has a real
+              // name); for pending invites the name line already is the email.
+              const subline = m.full_name ? (m.email || m.invited_email) : null
+              return (
+                <div
+                  key={m.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-slate-100 px-3 py-2.5 hover:bg-slate-50"
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium text-slate-800">{name}</span>
+                      {m.is_you && <span className="text-[10px] text-slate-400">(you)</span>}
+                    </div>
+                    {subline && <div className="truncate text-xs text-slate-500">{subline}</div>}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {pending ? (
+                      <>
+                        <span className="inline-flex items-center gap-1 rounded-full bg-orange-50 px-2 py-0.5 text-[11px] font-medium text-orange-600">
+                          <Clock className="h-3 w-3" /> Invited
+                        </span>
+                        {m.invite_token && (
+                          <button
+                            onClick={() => copyInviteLink(m)}
+                            className="inline-flex items-center gap-1 text-[11px] text-sky-600 hover:text-sky-800"
+                            title="Copy invite link"
+                          >
+                            {copiedId === m.id ? (
+                              <Check className="h-3.5 w-3.5 text-emerald-600" />
+                            ) : (
+                              <Copy className="h-3.5 w-3.5" />
+                            )}
+                            {copiedId === m.id ? "Copied" : "Copy link"}
+                          </button>
+                        )}
+                      </>
+                    ) : (
+                      <RoleBadge role={m.role} />
+                    )}
+                    {m.role !== "OWNER" && !m.is_you && (
+                      <button
+                        onClick={() => handleRemove(m)}
+                        className="text-slate-300 hover:text-red-500 transition-colors"
+                        title="Remove"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -22,6 +22,9 @@ import type {
   PaymentScheduleLineInput,
   ProjectFinancialSummary,
   ProjectScopeBilling,
+  TeamMember,
+  TeamInviteResponse,
+  InviteInfo,
 } from './types'
 import type { AutoReplySettings, TwilioAvailableNumber, TwilioProvisionResult } from './types/twilio'
 import type {
@@ -357,6 +360,35 @@ class ApiClient {
     })
   }
 
+  // ---- Team members -------------------------------------------------------
+  async listTeamMembers(): Promise<TeamMember[]> {
+    return this.request<TeamMember[]>('/team/members')
+  }
+
+  async inviteTeamMember(email: string, role: string = 'ADMIN', inviteBaseUrl?: string): Promise<TeamInviteResponse> {
+    return this.request<TeamInviteResponse>('/team/invite', {
+      method: 'POST',
+      body: JSON.stringify({ email, role, invite_base_url: inviteBaseUrl }),
+    })
+  }
+
+  async removeTeamMember(memberId: number): Promise<void> {
+    await this.request<void>(`/team/members/${memberId}`, { method: 'DELETE' })
+  }
+
+  /** Public: look up an invite by token (no auth required). */
+  async getInvite(token: string): Promise<InviteInfo> {
+    return this.request<InviteInfo>(`/team/invite/${token}`)
+  }
+
+  /** Public: accept an invite — creates the user and sets the session cookie. */
+  async acceptInvite(token: string, full_name: string, password: string) {
+    return this.request(`/team/invite/${token}/accept`, {
+      method: 'POST',
+      body: JSON.stringify({ full_name, password }),
+    })
+  }
+
   async updateLanguagePreference(locale: string) {
     return this.request('/contractors/profile', {
       method: 'PATCH',
@@ -496,8 +528,16 @@ class ApiClient {
     })
   }
 
-  async sendInvoiceViaEmail(invoiceId: number): Promise<{ message: string; status: string }> {
-    return this.request<{ message: string; status: string }>(`/invoices/${invoiceId}/send`, { method: 'POST' })
+  async sendInvoiceViaEmail(invoiceId: number, baseUrl?: string): Promise<{ message: string; status: string }> {
+    return this.request<{ message: string; status: string }>(`/invoices/${invoiceId}/send`, {
+      method: 'POST',
+      body: JSON.stringify({ base_url: baseUrl }),
+    })
+  }
+
+  /** Ensure the invoice has a public link and return it (for copy/share). */
+  async ensureInvoicePublicLink(invoiceId: number): Promise<{ public_link: string }> {
+    return this.request<{ public_link: string }>(`/invoices/${invoiceId}/public-link`, { method: 'POST' })
   }
 
   // --- Payment schedule (draws) ---

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -129,6 +129,8 @@ export interface User {
   is_active: boolean
   is_email_verified: boolean
   is_contractor?: boolean
+  /** Team role on the resolved account: OWNER / ADMIN / MEMBER (from /auth/me) */
+  role?: TeamMemberRole | null
   has_access?: boolean
   stripe_customer_id?: string
   stripe_subscription_id?: string
@@ -475,6 +477,38 @@ export interface PublicProposalLookup {
   proposal?: Proposal | null
 }
 
+// ---- Team members ---------------------------------------------------------
+export type TeamMemberRole = "OWNER" | "ADMIN" | "MEMBER"
+export type TeamMemberStatus = "INVITED" | "ACTIVE" | "REVOKED"
+
+export interface TeamMember {
+  id: number
+  user_id?: number | null
+  full_name?: string | null
+  email?: string | null
+  invited_email?: string | null
+  role: TeamMemberRole
+  status: TeamMemberStatus
+  is_you: boolean
+  invite_token?: string | null  // present for pending invites, to re-copy the link
+  created_at?: string
+  accepted_at?: string | null
+}
+
+export interface TeamInviteResponse {
+  member: TeamMember
+  invite_token: string
+  invite_url: string
+}
+
+export interface InviteInfo {
+  valid: boolean
+  company_name?: string | null
+  invited_email?: string | null
+  role?: TeamMemberRole | null
+  already_accepted?: boolean
+}
+
 export interface Job {
   id: number
   uuid: string
@@ -518,6 +552,9 @@ export interface Job {
   job_description?: string
   payment_terms?: string
   billing_mode?: JobBillingMode
+  /** Team member who created this quote (attribution) */
+  created_by_user_id?: number
+  created_by_name?: string
   customer_notes?: string
   /** Amount customer accepted when signing */
   accepted_total_amount?: number


### PR DESCRIPTION
This pull request introduces several user experience improvements and new features across the invite acceptance flow, quote and invoice displays, and public route handling. The main changes include a new invite acceptance page, enhanced client and attribution details in quotes and invoices, and improvements to public route detection and access control.

**New features and improvements:**

*Invite Acceptance and Public Route Handling:*
- Added a new `InviteAcceptPage` (`app/[locale]/(public)/invite/[token]/page.tsx`) that allows invited users to accept team invites, set their name and password, and handles invalid or expired invites gracefully. ([app/[locale]/(public)/invite/[token]/page.tsxR1-R140](diffhunk://#diff-8bcdbdef838a63323bf10b3e6da853ed59ef07ad90b60e32c4e8770ecda84e32R1-R140))
- Updated `AuthGuard` and `ConditionalShell` logic to treat invite acceptance routes as public, ensuring invited users can access them without authentication or contractor shell UI. [[1]](diffhunk://#diff-f58fa8f11e7a7299952f8b2152d3b903a17c6132a29e6173f52646c2e8af8d36R67-R69) [[2]](diffhunk://#diff-9afb336d8ff962d10bdf3483a7004e43d5b6350a636a31299064e62c31a14054R35-R37)

*Quote and Invoice UI Enhancements:*
- Improved the quote list UI to display client details (name, email, phone, address) with icons, and show who created the quote and when. Added `created_by_name` and `created_by_user_id` to the `Quote` type. ([app/[locale]/quotes/page.tsxL37-R37](diffhunk://#diff-42d1d05c7d8fed5b1b96efb783647067a92220bc8a9a89c962b63fcf1ebe20adL37-R37), [app/[locale]/quotes/page.tsxR61-R62](diffhunk://#diff-42d1d05c7d8fed5b1b96efb783647067a92220bc8a9a89c962b63fcf1ebe20adR61-R62), [app/[locale]/quotes/page.tsxL683-R725](diffhunk://#diff-42d1d05c7d8fed5b1b96efb783647067a92220bc8a9a89c962b63fcf1ebe20adL683-R725))
- In the personalized quote view, added a "Created by" attribution card for contractors, showing the creator's name and a local timestamp. [[1]](diffhunk://#diff-f7262fc5786e88b4d026f111f2876b87403c81e440f5923106b5de759657cb96L20-R20) [[2]](diffhunk://#diff-f7262fc5786e88b4d026f111f2876b87403c81e440f5923106b5de759657cb96R328-R341) [[3]](diffhunk://#diff-f7262fc5786e88b4d026f111f2876b87403c81e440f5923106b5de759657cb96R1387-R1409)
- Enhanced the invoice detail page with a "Send to Client" dropdown, allowing users to send invoices via email, SMS (with a preset message), or copy a public link. Also improved link generation and attribution. [[1]](diffhunk://#diff-a5b4bec716bb9ebe4f38584f8650cc4bb63dfece3aca6ea5812ff2857d0a97f6R27-R37) [[2]](diffhunk://#diff-a5b4bec716bb9ebe4f38584f8650cc4bb63dfece3aca6ea5812ff2857d0a97f6R102-R106) [[3]](diffhunk://#diff-a5b4bec716bb9ebe4f38584f8650cc4bb63dfece3aca6ea5812ff2857d0a97f6L167-R181) [[4]](diffhunk://#diff-a5b4bec716bb9ebe4f38584f8650cc4bb63dfece3aca6ea5812ff2857d0a97f6R195-R234) [[5]](diffhunk://#diff-a5b4bec716bb9ebe4f38584f8650cc4bb63dfece3aca6ea5812ff2857d0a97f6L633-R732) [[6]](diffhunk://#diff-a5b4bec716bb9ebe4f38584f8650cc4bb63dfece3aca6ea5812ff2857d0a97f6R878-R890)

These changes collectively improve the onboarding experience for invited users and provide clearer, more actionable client and attribution information throughout the app.…SMS/copy)

- Settings Team tab: invite by email, copy invite link, member list, remove; Billing tab hidden for non-owners
- public invite-accept page (/invite/[token]); whitelisted in auth-guard and conditional-shell
- 'Created by' on quotes list card and quote detail sidebar (browser-local time) with icons; account email shown in settings
- invoice detail: professional Send to Client dropdown (Email / SMS / Copy link), quote-style